### PR TITLE
Uppercase identifier `WriteFile()` at the beginning does not exist. Problem for building on Windows.

### DIFF
--- a/pipes.nim
+++ b/pipes.nim
@@ -4,7 +4,7 @@ when defined(windows):
   import winlean
 
   proc writeToPipe*(p: AsyncPipe, data: pointer, nbytes: int) =
-    if WriteFile(p.getWriteHandle, data, int32(nbytes), nil, nil) == 0:
+    if writeFile(p.getWriteHandle, data, int32(nbytes), nil, nil) == 0:
       raiseOsError(osLastError())
 
 else:


### PR DESCRIPTION
This fixes the package build for Windows.