### PR TITLE
fix pathToUri on windows

### DIFF
--- a/utils.nim
+++ b/utils.nim
@@ -101,10 +101,18 @@ proc pathToUri*(path: string): string =
   # the / character, meaning a full file path can be passed in without breaking
   # it.
   result = "file://" & newStringOfCap(path.len + path.len shr 2) # assume 12% non-alnum-chars
+  when defined(windows):
+    add(result, '/')
   for c in path:
     case c
     # https://tools.ietf.org/html/rfc3986#section-2.3
     of 'a'..'z', 'A'..'Z', '0'..'9', '-', '.', '_', '~', '/': add(result, c)
+    of '\\':
+      when defined(windows):
+        add(result, '/')
+      else:
+        add(result, '%')
+        add(result, toHex(ord(c), 2))
     else:
       add(result, '%')
       add(result, toHex(ord(c), 2))


### PR DESCRIPTION
current nimlangserver escapes windows-specific path characters when encoding URI's, breaking Sublime Text's LSP client