### PR TITLE
fix(main): write to stderr on exception

### DIFF
--- a/nimlangserver.nim
+++ b/nimlangserver.nim
@@ -942,8 +942,8 @@ when isMainModule:
       waitFor connection.start(pipeInput)
       quit(if ls.isShutdown: 0 else: 1)
     except Exception as ex:
-      echo "Shutting down due to an error: ", ex.msg
-      echo ex.getStackTrace()
+      stderr.writeLine("Shutting down due to an error: ", ex.msg)
+      stderr.writeLine(ex.getStackTrace())
       quit 1
 
   main()


### PR DESCRIPTION
I recently discovered this and am willing to switch to this over nimlsp.
Thanks for your amazing works.

Could you write the exceptions to `stderr` since my current setup (neovim) seems to not capture `stdout` when an error occurs.

Best,