### PR TITLE
Fix binary workflow

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -61,7 +61,9 @@ jobs:
         run: |
           ./nimble/nimble install
       - name: Compress the Nim Language Server binaries
-        run: tar -c -z -v -f nimlangserver-${{ matrix.target.os }}-${{ matrix.target.cpu }}.tar.gz nimlangserver{,.exe}
+        run: |
+          shopt -s extglob
+          tar -c -z -v -f nimlangserver-${{ matrix.target.os }}-${{ matrix.target.cpu }}.tar.gz nimlangserver@(|.exe)
 
       - name: Upload the Nim Language Server Binaries
         uses: actions/upload-artifact@v2

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,10 +2,10 @@ on:
   push:
     paths-ignore: ['media/**', 'docs/**', '**/*.md']
     branches:
-    - master
-    pull_request:
-      paths-ignore: ['media/**', 'docs/**', '**/*.md']
-    workflow_dispatch:
+      - master
+  pull_request:
+    paths-ignore: ['media/**', 'docs/**', '**/*.md']
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: jiro4989/setup-nim-action@v1.4.3
         with:
-          nimversion: ${{ matrix.nimversion }}
+          nim-version: stable
           yes: true
 
       - name: Install nimble


### PR DESCRIPTION
Saw there were some issues with the binary workflow to decided to fix them

- Indention in the `on` section was wrong which caused the workflow to not run for the improperly indented sections (see comment)
- Use the correct `nim-version` input for `setup-nim-action` and provide a version (The matrix doesn't have a `nimversion` variable).
- Use bash's extended globbing to properly match either `nimlangserver` or `nimlangserver.exe` when creating the zip

Finished run of the workflow available [here](https://github.com/ire4ever1190/langserver/actions/runs/5174579771)