### PR TITLE
Use a patched asynctools version in order to fix the issues on Windows

### DIFF
--- a/nimble.lock
+++ b/nimble.lock
@@ -192,12 +192,12 @@
     },
     "asynctools": {
       "version": "0.1.1",
-      "vcsRevision": "f1ad7289ff38f3b1c1987307845de373fc9af499",
-      "url": "https://github.com/yyoncho/asynctools",
+      "vcsRevision": "bb01d965a2ad0f08eaff6a53874f028ddbab4909",
+      "url": "https://github.com/nickysn/asynctools.git",
       "downloadMethod": "git",
       "dependencies": [],
       "checksums": {
-        "sha1": "e66b868cc432b4e28c6149715b567faea8429cd2"
+        "sha1": "7ac3e69cb9dfcedb140a707bcbd21a099904dafb"
       }
     },
     "json_rpc": {

--- a/nimlangserver.nimble
+++ b/nimlangserver.nimble
@@ -9,7 +9,7 @@ bin           = @["nimlangserver"]
 skipDirs      = @["tests"]
 
 requires "nim >= 1.0.0",
-         "https://github.com/yyoncho/asynctools#non-blocking",
+         "https://github.com/nickysn/asynctools#fixes_for_nimlangserver",
          "https://github.com/yyoncho/nim-json-rpc#notif-changes",
          "with",
          "chronicles"


### PR DESCRIPTION
This is a temporary fix, until we migrate the Nim language server to the Chronos library.