### PR TITLE
do not send TextEdit as nil.

### DIFF
--- a/protocol/types.nim
+++ b/protocol/types.nim
@@ -794,8 +794,8 @@ type
     filterText*: Option[string]
     insertText*: Option[string]
     insertTextFormat*: Option[int]
-    textEdit*: Option[TextEdit]
-    additionalTextEdits*: Option[TextEdit]
+    # textEdit*: Option[TextEdit]
+    # additionalTextEdits*: Option[TextEdit]
     commitCharacters*: OptionalSeq[string]
     command*: Option[Command]
     data*: OptionalNode


### PR DESCRIPTION
Fixes https://github.com/nim-lang/vscode-nim/issues/25 It seems like with the change of lsp from 3.16 to 3.17 sending null for certain fields break the feature.

In a following PR will make sure no null field is sent by adding a json hook.