### PR TITLE
+ support the logSuggest configuration option

### DIFF
--- a/nimlangserver.nim
+++ b/nimlangserver.nim
@@ -30,6 +30,7 @@ type
     autoRestart*: Option[bool]
     autoCheckFile*: Option[bool]
     autoCheckProject*: Option[bool]
+    logNimsuggest*: Option[bool]
 
   FileInfo = ref object of RootObj
     projectFile: Future[string]
@@ -467,7 +468,7 @@ proc createOrRestartNimsuggest(ls: LanguageServer, projectFile: string, uri = ""
                        MessageType.Error)
 
     nimsuggestFut = createNimsuggest(projectFile, nimsuggestPath,
-                                     timeout, restartCallback, errorCallback, workingDir)
+                                     timeout, restartCallback, errorCallback, workingDir, configuration.logNimsuggest.get(false))
     token = fmt "Creating nimsuggest for {projectFile}"
 
   if ls.projectFiles.hasKey(projectFile):

--- a/suggestapi.nim
+++ b/suggestapi.nim
@@ -300,7 +300,8 @@ proc createNimsuggest*(root: string,
                        timeout: int,
                        timeoutCallback: NimsuggestCallback,
                        errorCallback: NimsuggestCallback,
-                       workingDir = getCurrentDir()): Future[Nimsuggest] {.async, gcsafe.} =
+                       workingDir = getCurrentDir(),
+                       enableLog: bool = false): Future[Nimsuggest] {.async, gcsafe.} =
   var
     pipe = createPipe(register = true, nonBlockingWrite = false)
     thread: Thread[tuple[pipe: AsyncPipe, process: Process]]
@@ -326,6 +327,8 @@ proc createNimsuggest*(root: string,
       args = @[root, "--v" & $result.protocolVersion, "--autobind"]
     if result.protocolVersion >= 4:
       args.add("--clientProcessId:" & $getCurrentProcessId())
+    if enableLog:
+      args.add("--log")
     result.capabilities = getNimsuggestCapabilities(nimsuggestPath)
     result.process = startProcess(command = nimsuggestPath,
                                   workingDir = workingDir,


### PR DESCRIPTION
If set to true, pass the '--log' command line option to nimsuggest in order to enable debug logging to ~/nimsuggest.log

This configuration setting already exists in the VS code plugin, but it only works in the 'nimsuggest' backend mode. This change makes it work also in 'lsp' backend mode.