### PR TITLE
Revert "* CI: the macOS Universal binary jobs only needs the other tw…

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -115,7 +115,7 @@ jobs:
 
   create-macos-universal-binary:
     name: Create a Universal macOS binary
-    needs: [x86_64-apple-darwin14, aarch64-apple-darwin14]
+    needs: [build]
     runs-on: macos-11
     steps:
       - name: Download artifacts


### PR DESCRIPTION
…o macOS jobs to be finished, before it can start (#121)"

This reverts commit ba0741b8c31481e0d734c202c1f154b494110f45.