### PR TITLE
* CI: use the correct value for nimble_cpu - it should reflect the CPU…

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -25,13 +25,13 @@ jobs:
             name: linux
             cpu: i686
             nim_cpu: i386
-            nimble_cpu: i386
+            nimble_cpu: amd64
           - os: linux
             triple: aarch64-linux-musl
             name: linux
             cpu: arm64
             nim_cpu: arm64
-            nimble_cpu: aarch64
+            nimble_cpu: amd64
           - os: macos
             triple: x86_64-apple-darwin14
             name: macos


### PR DESCRIPTION
…of the builder, not the target (the two are sometimes different, because, for some targets we use crosscompilation).

The reason it worked previously, is because the Nimble release builds are broken - they are all x86_64, even though they say they are something else.