### PR TITLE
- CI: don't add the nimlangserver (without the .exe extension) binary…

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -121,7 +121,12 @@ jobs:
 
       - name: Compress the Nim Language Server binaries
         run: |
-          tar -czvf nimlangserver-${{ matrix.target.name }}-${{ matrix.target.cpu }}.tar.gz `ls nimlangserver{,.exe} 2>/dev/null || true`
+          if [ ${{ matrix.target.name }} = 'windows' ]; then
+            EXEEXT=.exe
+          else
+            EXEEXT=
+          fi
+          tar -czvf nimlangserver-${{ matrix.target.name }}-${{ matrix.target.cpu }}.tar.gz nimlangserver${EXEEXT}
 
       - name: Upload the Nim Language Server Binaries
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
… to the archive when building for Windows