### PR TITLE
* avoid a race condition on startup, when certain commands arrive too…

### DIFF
--- a/nimlangserver.nim
+++ b/nimlangserver.nim
@@ -297,8 +297,12 @@ proc uriToStash(ls: LanguageServer, uri: string): string =
   else:
     ""
 
+proc createOrRestartNimsuggest(ls: LanguageServer, projectFile: string, uri = ""): void {.gcsafe.}
+
 proc getNimsuggest(ls: LanguageServer, uri: string): Future[Nimsuggest] {.async.} =
   let projectFile = await ls.openFiles[uri].projectFile
+  if not ls.projectFiles.hasKey(projectFile):
+    ls.createOrRestartNimsuggest(projectFile, uri)
   ls.lastNimsuggest = ls.projectFiles[projectFile]
   return await ls.projectFiles[projectFile]
 


### PR DESCRIPTION
… early from the LSP client, before nimsuggest initialization has started