### PR TITLE
* made the result of 'shutdown' to be 'null', which conforms to the …

### DIFF
--- a/nimlangserver.nim
+++ b/nimlangserver.nim
@@ -1120,9 +1120,7 @@ proc shutdown(ls: LanguageServer, input: JsonNode): Future[RpcResult] {.async, g
   await ls.stopNimsuggestProcesses()
   ls.isShutdown = true
   let id = input{"id"}.extractId
-  result = some(  StringOfJson(
-    """{"jsonrpc":"2.0","result":null,"id":$1}""" % [$id] & "\r\n")
-  )
+  result = some(StringOfJson("null"))
   trace "Shutdown complete"
 
 proc exit(p: tuple[ls: LanguageServer, pipeInput: AsyncInputStream], _: JsonNode):


### PR DESCRIPTION
…LSP spec (even though VS Code ignores it, it's always good to follow the spec, just in case)