### PR TITLE
+ added nimsuggest feature detection for exception inlay hints. If detected,

### DIFF
--- a/suggestapi.nim
+++ b/suggestapi.nim
@@ -76,7 +76,8 @@ type
     tooltip*: string
 
   NimSuggestCapability* = enum 
-    nsCon = "con"
+    nsCon = "con",
+    nsExceptionInlayHints = "exceptionInlayHints"
 
   Nimsuggest* = ref object
     failed*: bool
@@ -312,7 +313,8 @@ proc createNimsuggest*(root: string,
                        timeoutCallback: NimsuggestCallback,
                        errorCallback: NimsuggestCallback,
                        workingDir = getCurrentDir(),
-                       enableLog: bool = false): Future[Nimsuggest] {.async, gcsafe.} =
+                       enableLog: bool = false,
+                       enableExceptionInlayHints: bool = false): Future[Nimsuggest] {.async, gcsafe.} =
   var
     pipe = createPipe(register = true, nonBlockingWrite = false)
     thread: Thread[tuple[pipe: AsyncPipe, process: Process]]
@@ -341,6 +343,11 @@ proc createNimsuggest*(root: string,
     if enableLog:
       args.add("--log")
     result.capabilities = getNimsuggestCapabilities(nimsuggestPath)
+    if nsExceptionInlayHints in result.capabilities:
+      if enableExceptionInlayHints:
+        args.add("--exceptionInlayHints:on")
+      else:
+        args.add("--exceptionInlayHints:off")
     result.process = startProcess(command = nimsuggestPath,
                                   workingDir = workingDir,
                                   args = args,


### PR DESCRIPTION
  pass the new command line option to nimsuggest `--exceptionInlayHints:on|off`,
  according to whether exception inlay hints are enabled in config.

Resolves #162.