### PR TITLE
* bump version in the master branch to 1.3.1, following a similar number.odd.odd

### DIFF
--- a/nimlangserver.nimble
+++ b/nimlangserver.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "nimlangserver"
-version       = "1.2.0"
+version       = "1.3.1"
 author        = "The core Nim team"
 description   = "Nim language server for IDEs"
 license       = "MIT"


### PR DESCRIPTION
  scheme for development versions that Nim uses.