### PR TITLE
* in case rootUri is null, but rootPath is set, take rootPath instead of using

### DIFF
--- a/nimlangserver.nim
+++ b/nimlangserver.nim
@@ -177,7 +177,10 @@ proc getWorkspaceConfiguration(ls: LanguageServer): Future[NlsConfig] {.async.} 
 
 proc getRootPath(ip: InitializeParams): string =
   if ip.rootUri.isNone or ip.rootUri.get == "":
-    return getCurrentDir().pathToUri.uriToPath
+    if ip.rootPath.isSome and ip.rootPath.get != "":
+      return ip.rootPath.get
+    else:
+      return getCurrentDir().pathToUri.uriToPath
   return ip.rootUri.get.uriToPath
 
 proc getProjectFile(fileUri: string, ls: LanguageServer): Future[string] {.async.} =


### PR DESCRIPTION
  the current directory. This should improve performance with editors that only
  send rootPath, but no rootUri, such as Helix. Fixes #59.