### PR TITLE
Introduces `extension/status`

### DIFF
--- a/protocol/types.nim
+++ b/protocol/types.nim
@@ -971,3 +971,19 @@ type
     paddingLeft*: Option[bool]
     paddingRight*: Option[bool]
     #data*: OptionalNode
+  
+  NimSuggestStatus* = object
+    projectFile*: string
+    capabilities*: seq[string]
+    version*: string
+    path*: string
+    pid*: int
+    knownFiles*: seq[string]
+    unknownFiles*: seq[string]
+  
+  NimLangServerStatus* = ref object
+    version*: string
+    nimsuggestInstances*: seq[NimSuggestStatus]
+
+  NimLangServerStatusParams* = ref object
+    

--- a/tests/tprojectsetup.nim
+++ b/tests/tprojectsetup.nim
@@ -199,6 +199,15 @@ suite "nimble setup":
     res = client.call("textDocument/completion", %completionParams).waitFor
     let completionList = res.to(seq[CompletionItem]).mapIt(it.label)
     check completionList.len > 0
+
+    var resStatus =  client.call("extension/status", %()).waitFor
+    let status = resStatus.to(NimLangServerStatus)[]
+    check status.nimsuggestInstances.len == 1
+    let nsInfo = status.nimsuggestInstances[0]
+    check nsInfo.projectFile == entryPoint
+    check nsInfo.knownFiles.len == 1
+    check nsInfo.knownFiles[0] == entryPoint
+    check nsInfo.unknownFiles.len == 0
   
   # test "`submodule.nim` should not be part of the nimble project file":
   #   let testProjectDir = absolutePath "tests" / "projects" / "testproject"


### PR DESCRIPTION
It's useful for asserting in tests in a reliable way as it exposes the langserver and nimsuggest instances current status (i.e. main file, known files, etc.) It can also be useful to create a specific window in extension to quickly inspect the current status for a given project