### PR TITLE
Expands how cancellable requests work

### DIFF
--- a/ls.nim
+++ b/ls.nim
@@ -310,18 +310,13 @@ proc sendStatusChanged*(ls: LanguageServer) {.raises: [].}  =
 
 proc addProjectFileToPendingRequest*(ls: LanguageServer, id: uint, uri: string) {.async.}= 
   if id in ls.pendingRequests:
-    debug "[addProjectFileToPendingRequest] ", uri = uri, path = uriToPath(uri)
     var projectFile = uri.uriToPath()
     if projectFile notin ls.projectFiles:
       if uri in ls.openFiles:
-        debug "[addProjectFileToPendingRequest] uri in ls.openFiles", uri = uri, path = uriToPath(uri)
-
         projectFile = await ls.openFiles[uri].projectFile 
 
     ls.pendingRequests[id].projectFile = some projectFile 
     ls.sendStatusChanged
-  else:
-     debug "[addProjectFileToPendingRequest] id not in pendingRequests"
 
 proc requiresDynamicRegistrationForDidChangeConfiguration(ls: LanguageServer): bool =
   ls.clientCapabilities.workspace.isSome and

--- a/protocol/types.nim
+++ b/protocol/types.nim
@@ -976,6 +976,11 @@ type
     nsCon = "con",
     nsExceptionInlayHints = "exceptionInlayHints"
     nsUnknownFile = "unknownFile"
+  
+  PendingRequestStatus* = object
+    name*: string
+    projectFile*: string
+    time*: string 
 
   NimSuggestStatus* = object
     projectFile*: string
@@ -994,6 +999,7 @@ type
     nimsuggestInstances*: seq[NimSuggestStatus]
     openFiles*: seq[string]
     extensionCapabilities*: seq[LspExtensionCapability]
+    pendingRequests*: seq[PendingRequestStatus]
 
   NimLangServerStatusParams* = object
   


### PR DESCRIPTION
Now they are `PendingRequests` and we keep track of the nimsuggest instance that depends on it (when possible) and also the time it got triggered. The pending requests are shown in the extension status panel, later we will be using the active pending requests to determine if a given instance of ns is hanging so we can restart it without user intervention

![image](https://github.com/user-attachments/assets/4b100f76-cd0e-42fc-9837-d0c3d41f8e75)

Notice the `Pending Requests (15)` in the img above are there because the ls is not removing complete requests, but in a regular usage they shouldnt be there (we may introduce a toggle for debugging purposes that dont remove them when complete) or we could just show all and remove complete ones after certain period has passed since it was completed