### PR TITLE
Fix compile on Windows

### DIFF
--- a/asyncprocmonitor.nim
+++ b/asyncprocmonitor.nim
@@ -10,7 +10,7 @@ when defined(posix):
 type Callback* = proc() {.closure, gcsafe, raises: [].}
 
 when defined(windows):
-  import winlean
+  import winlean, sugar
 
   proc hookAsyncProcMonitor*(pid: int, cb: Callback) =
     discard addProcess2(pid, (arg: pointer) => cb())


### PR DESCRIPTION
The `when defined(windows):` block needs the sugar module. This PR adds back the import there.