### PR TITLE
Fix `Position` type

### DIFF
--- a/protocol/types.nim
+++ b/protocol/types.nim
@@ -5,13 +5,14 @@ import tables
 type
   OptionalSeq*[T] = Option[seq[T]]
   OptionalNode* = Option[JsonNode]
+  uinteger* = range[0 .. (1 shl 31 - 1)]
 
   CancelParams* = ref object of RootObj
     id*: OptionalNode
 
   Position* = ref object of RootObj
-    line*: int # uinteger
-    character*: int # uinteger
+    line*: uinteger
+    character*: uinteger
 
   Range* = ref object of RootObj
     start*: Position
@@ -397,7 +398,7 @@ type
 
   FoldingRangeClientCapabilities* = ref object of RootObj
     dynamicRegistration*: Option[bool]
-    rangeLimit*: Option[int] # uinteger
+    rangeLimit*: Option[uinteger]
     lineFoldingOnly*: Option[bool]
     foldingRangeKind*: Option[FoldingRangeClientCapabilities_foldingRangeKind]
     foldingRange*: Option[FoldingRangeClientCapabilities_foldingRange]

--- a/routes.nim
+++ b/routes.nim
@@ -733,7 +733,7 @@ proc format*(
 
   let fullRange = Range(
     start: Position(line: 0, character: 0),
-    `end`: Position(line: int(uint32.high), character: int(uint32.high)),
+    `end`: Position(line: uinteger.high, character: uinteger.high)
   )
   debug "Formatting document", uri = uri, formattedText = formattedText
   some TextEdit(range: fullRange, newText: formattedText)


### PR DESCRIPTION
Unlike Nim's `uint32`, LSP's `uinteger` has an upper bound of 2^31-1. It breaks formatting in Sublime Text.