### PR TITLE
ci: Cache .cache/nim, add hashed lockfile to cache key

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -108,8 +108,12 @@ jobs:
         id: nimble_deps
         uses: actions/cache@v4
         with:
-          path: ~/.nimble/
-          key: ${{ matrix.target.os }}-${{ env.cache_nonce }}
+          path: |
+            ~/.nimble
+            ~/.cache/nim
+          key: ${{ matrix.target.os }}-${{ env.cache_nonce }}-${{ hashFiles('**/nimble.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache_nonce }}-
 
       - name: build nimlangserver
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,17 @@ jobs:
         id: nimble_deps
         uses: actions/cache@v4
         with:
-          path: ~/.nimble/
-          key: ${{ matrix.os }}-${{ env.cache_nonce }}
+          path: |
+            ~/.nimble
+            ~/.cache/nim
+          key: ${{ matrix.target.os }}-${{ env.cache_nonce }}-${{ hashFiles('**/nimble.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache_nonce }}-
 
-      - name: Nimble Install
+      - name: Install dependencies
         shell: bash
-        run: |
-          nimble -y install -l
+        run: nimble -y install -l
       
       - name: Nimble Test
         shell: bash
-        run: |
-          nimble test
+        run: nimble test


### PR DESCRIPTION
Caching was not set up properly, causing`nimble install` to take [90% of the CI's time](https://github.com/nim-lang/langserver/actions/runs/16434039589/job/46440580901).  When I instituted [similar changes](https://github.com/esafak/seance/pull/9) in my own workflows, [nimble install only took two seconds](https://github.com/esafak/seance/actions).