### PR TITLE
Fix #387: Remove null-value fields from JSON output

### DIFF
--- a/lstransports.nim
+++ b/lstransports.nim
@@ -83,7 +83,7 @@ proc wrapRpc*[T](fn: proc(params: T): Future[auto] {.gcsafe, raises: [].}): Rpc 
         JsonString("{}") #Client doesnt expect a response. Handled in processMessage
     else:
       let res = await fn(val)
-      return JsonString($(%*res))
+      return JsonString($((%*res).withoutNulls))
 
 proc wrapRpc*[T](
     fn: proc(params: T, id: int): Future[auto] {.gcsafe, raises: [].}
@@ -96,7 +96,7 @@ proc wrapRpc*[T](
     except KeyError:
       error "IdRequest not found in the request params", params = params
     let res = await fn(val, idRequest)
-    return JsonString($(%*res))
+    return JsonString($((%*res).withoutNulls))
 
 proc addRpcToCancellable*(ls: LanguageServer, rpc: Rpc): Rpc =
   return proc(params: RequestParamsRx): Future[JsonString] {.gcsafe, raises: [].} =

--- a/lstransports.nim
+++ b/lstransports.nim
@@ -40,6 +40,40 @@ proc toJson*(params: RequestParamsRx): JsonNode =
     for p in params.positional:
       result.add parseJson($p)
 
+func withoutNulls(n: JsonNode): JsonNode =
+  ## Return a JObject or JArray without any null nodes.
+
+  doAssert n.kind in [JObject, JArray, JNull]
+
+  case n.kind
+  of JObject:
+    result = newJObject()
+
+    for k, v in n:
+      case v.kind
+      of JNull:
+        discard
+      of JObject, JArray:
+        result[k] = v.withoutNulls
+      else:
+        result[k] = v
+  of JArray:
+    result = newJArray()
+
+    for v in n:
+      case v.kind
+      of JNull:
+        discard
+      of JObject, JArray:
+        result.add(v.withoutNulls)
+      else:
+        result.add(v)
+  of JNull:
+    result = newJObject()
+  else:
+    # This never happens because of the assertion above
+    discard
+
 proc wrapRpc*[T](fn: proc(params: T): Future[auto] {.gcsafe, raises: [].}): Rpc =
   return proc(params: RequestParamsRx): Future[JsonString] {.gcsafe, async.} =
     var val = params.to(T)

--- a/lstransports.nim
+++ b/lstransports.nim
@@ -42,6 +42,7 @@ proc toJson*(params: RequestParamsRx): JsonNode =
 
 func withoutNulls(n: JsonNode): JsonNode =
   ## Return a JObject or JArray without any null nodes.
+  ## If a JNull node is passed in, it is returned as is.
 
   doAssert n.kind in [JObject, JArray, JNull]
 
@@ -69,7 +70,7 @@ func withoutNulls(n: JsonNode): JsonNode =
       else:
         result.add(v)
   of JNull:
-    result = newJObject()
+    result = newJNull()
   else:
     # This never happens because of the assertion above
     discard

--- a/tests/lspsocketclient.nim
+++ b/tests/lspsocketclient.nim
@@ -144,7 +144,9 @@ proc register*(client: LspSocketClient, name: string, rpc: Rpc) =
 proc initialize*(
     client: LspSocketClient, initParams: InitializeParams
 ): Future[InitializeResult] {.async.} =
-  client.call("initialize", %initParams).await.jsonTo(InitializeResult)
+  client.call("initialize", %initParams).await.jsonTo(
+    InitializeResult, Joptions(allowMissingKeys: true)
+  )
 
 proc createDidOpenParams*(file: string): DidOpenTextDocumentParams =
   return

--- a/tests/textensions.nim
+++ b/tests/textensions.nim
@@ -112,7 +112,7 @@ suite "Nimlangserver extensions":
 
     let runTestsParams = RunTestParams(entryPoint: "tests/projects/testrunner/tests/sampletests.nim".absolutePath)
     let runTestsRes = client.call("extension/runTests", jsonutils.toJson(runTestsParams)).waitFor().jsonTo(
-        RunTestProjectResult
+        RunTestProjectResult, Joptions(allowMissingKeys: true)
       )
     check runTestsRes.suites.len == 4
     check runTestsRes.suites[0].name == "Sample Tests"
@@ -135,7 +135,7 @@ suite "Nimlangserver extensions":
     let suiteName = "Sample Suite"
     let runTestsParams = RunTestParams(entryPoint: "tests/projects/testrunner/tests/sampletests.nim".absolutePath, suiteName: some suiteName)
     let runTestsRes = client.call("extension/runTests", jsonutils.toJson(runTestsParams)).waitFor().jsonTo(
-        RunTestProjectResult
+        RunTestProjectResult, Joptions(allowMissingKeys: true)
       )
     check runTestsRes.suites.len == 1
     check runTestsRes.suites[0].name == suiteName
@@ -154,7 +154,7 @@ suite "Nimlangserver extensions":
 
     let testName = "Sample Test"
     let runTestsParams = RunTestParams(entryPoint: "tests/projects/testrunner/tests/sampletests.nim".absolutePath, testNames: some @[testName])
-    let runTestsRes = client.call("extension/runTests", jsonutils.toJson(runTestsParams)).waitFor().jsonTo(RunTestProjectResult)
+    let runTestsRes = client.call("extension/runTests", jsonutils.toJson(runTestsParams)).waitFor().jsonTo(RunTestProjectResult, Joptions(allowMissingKeys: true))
 
     check runTestsRes.suites.len == 1
     check runTestsRes.suites[0].tests == 1
@@ -172,7 +172,7 @@ suite "Nimlangserver extensions":
 
       let testNames = @["Sample Test", "Sample Test 2"]
       let runTestsParams = RunTestParams(entryPoint: "tests/projects/testrunner/tests/sampletests.nim".absolutePath, testNames: some testNames)
-      let runTestsRes = client.call("extension/runTests", jsonutils.toJson(runTestsParams)).waitFor().jsonTo(RunTestProjectResult)
+      let runTestsRes = client.call("extension/runTests", jsonutils.toJson(runTestsParams)).waitFor().jsonTo(RunTestProjectResult, Joptions(allowMissingKeys: true))
 
     check runTestsRes.suites.len == 1
   #   check runTestsRes.suites[0].tests == 2
@@ -189,7 +189,7 @@ suite "Nimlangserver extensions":
     let initializeResult = waitFor client.initialize(initParams)
 
     let runTestsParams = RunTestParams(entryPoint: "tests/projects/testrunner/tests/failingtest.nim".absolutePath)
-    let runTestsRes = client.call("extension/runTests", jsonutils.toJson(runTestsParams)).waitFor().jsonTo(RunTestProjectResult)
+    let runTestsRes = client.call("extension/runTests", jsonutils.toJson(runTestsParams)).waitFor().jsonTo(RunTestProjectResult, Joptions(allowMissingKeys: true))
 
     check runTestsRes.suites.len == 1
     check runTestsRes.suites[0].name == "Failing Tests"

--- a/tests/textensions.nim
+++ b/tests/textensions.nim
@@ -91,7 +91,7 @@ suite "Nimlangserver extensions":
 
     let listTestsParams = ListTestsParams(entryPoint: "tests/projects/testrunner/tests/sampletests.nim".absolutePath)
     let tests = client.call("extension/listTests", jsonutils.toJson(listTestsParams)).waitFor().jsonTo(
-        ListTestsResult
+        ListTestsResult, Joptions(allowMissingKeys: true)
       )
     let testProjectInfo = tests.projectInfo
     check testProjectInfo.suites.len == 3


### PR DESCRIPTION
Neovim 0.12+ is especially sensitive to optional fields: they mustn't be present, not simply be `null`s.

To ensure this strict protocol, I added an additional sanitation step to wrapRpc that removes all null-value fields from the returned objects.