### PR TITLE
Fix #391: Compilation on macOS

### DIFF
--- a/nimlangserver.nims
+++ b/nimlangserver.nims
@@ -1,0 +1,2 @@
+if defined(clang):
+  switch("passC", "-Wno-incompatible-pointer-types")


### PR DESCRIPTION
Fixes #391:
- adds necessary compilation flags for clang
- bumps bearssl and chronos