### PR TITLE
Defer nimsuggest instance init out of MCP initialize handler

### DIFF
--- a/routes/mcp.nim
+++ b/routes/mcp.nim
@@ -416,11 +416,11 @@ proc initialize*(
     serverInfo:
       McpInitializeParams_serverInfo(name: "nimlangserver", version: LSPVersion),
   )
-  debug "Initialize completed. Trying to start nimsuggest instances"
+  debug "Initialize completed. Spawning nimsuggest instance startup"
   let ls = p.ls
   ls.mcpServerCapabilities = result.capabilities
   let rootPath = getCurrentDir().pathToUri.uriToPath
-  await ls.initNimsuggestInstances(rootPath)
+  asyncSpawn ls.initNimsuggestInstances(rootPath)
 
 proc listTools*(
     ls: LanguageServer, params: McpListToolsParams


### PR DESCRIPTION
The MCP `initialize` handler previously awaited `initNimsuggestInstances` before returning a response. This can be slow or hang (running `nimble dump`, starting nimsuggest processes). With some harnesses time-outs (30 second for OpenCode), a delayed initialize response causes the MCP connection to fail entirely, before any tool can be used.

MCP protocol expects the server to respond to `initialize` promptly, then handle the `notifications/initialized` message. Heavy initialization should happen after the handshake.

Fix: replace `await` with `asyncSpawn` so the initialize response is sent immediately and nimsuggest startup proceeds in the background.