### PR TITLE
send JSON-RPC error response when a request handler throws

### DIFF
--- a/lstransports.nim
+++ b/lstransports.nim
@@ -213,6 +213,12 @@ proc runRpc(ls: LanguageServer, req: RequestRx, rpc: RpcProc): Future[void] {.as
   except CatchableError as ex:
     error "[RunRPC] ", msg = ex.msg, req = req.`method`
     writeStackTrace(ex = ex)
+    var errJson = newJObject()
+    errJson["jsonrpc"] = %*"2.0"
+    if req.id.kind == riNumber:
+      errJson["id"] = %*req.id.num
+    errJson["error"] = %*{"code": -32603, "message": ex.msg}
+    ls.writeOutput(errJson)
 
 proc processMessage(ls: LanguageServer, message: string) {.raises: [].} =
   try:


### PR DESCRIPTION
When a request handler raises an exception, runRpc catches it and logs the error but never sends a response back to the client. The MCP client's pending request hangs until its own timeout of 30 seconds for OpenCode, making the server appear unresponsive and wasting time on every failure.
    
Fix: construct a JSON-RPC error response with code -32603 and the exception message, then write it to the transport output.