### PR TITLE
Let child process stderr inherit from parent in getNimbleDumpInfo

### DIFF
--- a/ls.nim
+++ b/ls.nim
@@ -280,7 +280,7 @@ proc getNimbleDumpInfo*(
       "nimble",
       arguments = @["dump", nimbleFile],
       options = {UsePath},
-      stderrHandle = AsyncProcess.Pipe,
+      stderrHandle = ProcessStreamHandle(),
       stdoutHandle = AsyncProcess.Pipe,
     )
     let info = string.fromBytes(process.stdoutStream.read().await)

--- a/ls.nim
+++ b/ls.nim
@@ -280,7 +280,8 @@ proc getNimbleDumpInfo*(
       "nimble",
       arguments = @["dump", nimbleFile],
       options = {UsePath},
-      stderrHandle = AsyncProcess.Pipe,
+      stderrHandle = ProcessStreamHandle(), # None => chronos doesn't
+      # manage stderr, child inherits ours
       stdoutHandle = AsyncProcess.Pipe,
     )
     let info = string.fromBytes(process.stdoutStream.read().await)
@@ -330,8 +331,8 @@ proc getWorkspaceConfiguration*(
 ): Future[NlsConfig] {.async: (raises: []).} =
   try:
     #this is the root of a lot a problems as there are multiple race conditions here.
-    #since most request doenst really rely on the configuration, we can just go ahead and 
-    #return a default one until we have the right one. 
+    #since most request doesn't really rely on the configuration, we can just go ahead and
+    #return a default one until we have the right one.
     #TODO review and handle project specific confs when received instead of reliying in this func
     if ls.workspaceConfiguration.finished:
       return parseWorkspaceConfiguration(ls.workspaceConfiguration.read)


### PR DESCRIPTION
getNimbleDumpInfo pipes the child process's stderr but never reads it. This silently discards any diagnostics nimble produces on stderr and needlessly consumes a file descriptor. In extreme cases it could also cause a pipe deadlock if the child writes enough stderr data to fill the pipe buffer before stdout closes.

Fix: use an empty ProcessStreamHandle for stderr instead of piping. The child's stderr inherits from the parent process's stderr, which the editor or MCP host already captures and logs.