### PR TITLE
add timeout guard for nimsuggest startup

### DIFF
--- a/ls.nim
+++ b/ls.nim
@@ -1074,7 +1074,7 @@ proc createOrRestartNimsuggest*(
 
     debug "Creating new nimsuggest project", projectFile = projectFile
 
-    let projectNext = waitFor createNimsuggest(
+    let projectFut = createNimsuggest(
       projectFile,
       nimsuggestPath,
       version,
@@ -1085,7 +1085,13 @@ proc createOrRestartNimsuggest*(
       configuration.logNimsuggest.get(false),
       configuration.exceptionHintsEnabled,
     )
+    let projectOpt = waitFor utils.withTimeout(projectFut, NIMSUGGEST_STARTUP_TIMEOUT)
 
+    if projectOpt.isNone:
+      error "Nimsuggest startup timed out", projectFile = projectFile
+      return
+
+    let projectNext = projectOpt.get
     if projectFile in ls.projectFiles:
       var project = ls.projectFiles[projectFile]
       project.stop()

--- a/ls.nim
+++ b/ls.nim
@@ -330,8 +330,8 @@ proc getWorkspaceConfiguration*(
 ): Future[NlsConfig] {.async: (raises: []).} =
   try:
     #this is the root of a lot a problems as there are multiple race conditions here.
-    #since most request doenst really rely on the configuration, we can just go ahead and 
-    #return a default one until we have the right one. 
+    #since most request doesn't really rely on the configuration, we can just go ahead and
+    #return a default one until we have the right one.
     #TODO review and handle project specific confs when received instead of reliying in this func
     if ls.workspaceConfiguration.finished:
       return parseWorkspaceConfiguration(ls.workspaceConfiguration.read)
@@ -1074,7 +1074,7 @@ proc createOrRestartNimsuggest*(
 
     debug "Creating new nimsuggest project", projectFile = projectFile
 
-    let projectNext = waitFor createNimsuggest(
+    let projectFut = createNimsuggest(
       projectFile,
       nimsuggestPath,
       version,
@@ -1085,7 +1085,13 @@ proc createOrRestartNimsuggest*(
       configuration.logNimsuggest.get(false),
       configuration.exceptionHintsEnabled,
     )
+    if not waitFor chronos.withTimeout(
+      projectFut, chronos.milliseconds(NIMSUGGEST_STARTUP_TIMEOUT)
+    ):
+      error "Nimsuggest startup timed out", projectFile = projectFile
+      return
 
+    let projectNext = waitFor projectFut
     if projectFile in ls.projectFiles:
       var project = ls.projectFiles[projectFile]
       project.stop()

--- a/suggestapi.nim
+++ b/suggestapi.nim
@@ -18,6 +18,7 @@ import
   stew/[byteutils]
 
 const REQUEST_TIMEOUT* = 120000
+const NIMSUGGEST_STARTUP_TIMEOUT* = 30000
 const HighestSupportedNimSuggestProtocolVersion = 4
 
 # copied from Nim repo


### PR DESCRIPTION
`createOrRestartNimsuggest` blocks on `waitFor(createNimsuggest(...))` which can hang indefinitely if nimsuggest fails to start or becomes unresponsive. This blocks tool calls and the MCP client eventually times out after 30 seconds, wasting time on every failure.

Fix: wrap the createNimsuggest call in utils.withTimeout with a configurable `NIMSUGGEST_STARTUP_TIMEOUT` of 30 seconds. On timeout, the nimsuggest future is cancelled and the proc returns early with an error log instead of blocking the caller.