### PR TITLE
Fix SIGSEGV in writeOutput when writing after stdio teardown

### DIFF
--- a/lstransports.nim
+++ b/lstransports.nim
@@ -190,6 +190,9 @@ proc writeOutput*(ls: LanguageServer, content: JsonNode) =
   try:
     case ls.transportMode
     of stdio:
+      # writing to a closed FILE is a SIGSEGV in libc, not a CatchableError
+      if ls.outStream.isNil:
+        return
       ls.outStream.write(res)
       ls.outStream.flush()
     of socket:
@@ -260,7 +263,9 @@ proc initActions*(ls: LanguageServer) =
   let onExit: OnExitCallback = proc() {.async.} =
     case ls.transportMode
     of stdio:
-      ls.outStream.close()
+      if not ls.outStream.isNil:
+        ls.outStream.close()
+        ls.outStream = nil
       freeShared(ls.stdinContext)
     of socket:
       ls.srv.close()

--- a/tests/tmisc.nim
+++ b/tests/tmisc.nim
@@ -47,3 +47,17 @@ suite "Nimlangserver misc":
     check waitFor client.waitForNotificationMessage(
       fmt"Nimsuggest for {hwAbsFile} was stopped because it was idle for too long",
     )
+
+suite "Nimlangserver transport teardown":
+  test "writeOutput drops writes after the stdio stream is torn down":
+    # Regression test for #418: an in-flight runRpc continuation resuming after
+    # onExit closed ls.outStream wrote to a closed FILE and SIGSEGV'd inside
+    # libc fwrite. Test approach: the real crash needs a stdio teardown racing
+    # an async write and cannot be reproduced in-process without taking the
+    # test runner down with it, so we exercise the guarded state instead —
+    # after onExit, outStream is nil and a late writeOutput must be a no-op
+    # (pre-fix this dereferences a nil stream and dies).
+    let ls = LanguageServer(serverMode: lsp, transportMode: stdio)
+    doAssert ls.outStream.isNil
+    ls.writeOutput(%*{"jsonrpc": "2.0", "id": 1, "result": newJNull()})
+    check ls.outStream.isNil


### PR DESCRIPTION
## Summary

Fixes #418 — a hard SIGSEGV in `writeOutput` (stdio transport) when a response is written after `onExit` has closed `ls.outStream`.

## Root cause

`runRpc` is async; when the client sends `exit` (or restarts the server) while a response is still in flight, `onExit` closes `ls.outStream` but leaves the handle pointing at the closed `FileStream`. The resumed continuation then calls `writeOutput`, which writes to the closed `FILE` and faults inside libc (`fwrite` → `flockfile`, reading offset `0x68` of a freed `FILE`). The surrounding `try/except CatchableError` cannot catch this — it is a hardware fault, not an `IOError` — so the whole server dies, observed as 8 identical macOS crash reports (backtrace in the issue).

## Fix

- `onExit` nils the stream handle after closing it. chronos is cooperatively scheduled and there is no `await` between `close()` and `= nil`, so the pair is atomic w.r.t. other tasks.
- `writeOutput` drops writes when the handle is nil (server is tearing down; the client is gone).

## Test

The real crash needs a stdio teardown racing an async write and can't be reproduced in-process without taking the test runner down with it, so the test exercises the guarded state instead: a stdio-mode server whose `outStream` is nil (the post-`onExit` state) must treat a late `writeOutput` as a no-op. Before the fix this test dies with `SIGSEGV: Illegal storage access`; after it, the full suite passes (46/46).

Verified locally against a live editor session as well (Zed + stdio): with this fix (plus #419) a wedged server recovers via the IDE's "restart language server" instead of requiring a full IDE restart.
