### PR TITLE
Prevent CancelledError escaping addProjectFileToPendingRequest killing the server

### DIFF
--- a/ls.nim
+++ b/ls.nim
@@ -430,14 +430,19 @@ proc sendStatusChanged*(ls: LanguageServer) {.raises: [].} =
 proc addProjectFileToPendingRequest*(
     ls: LanguageServer, id: uint, uri: string
 ) {.async.} =
-  if id in ls.pendingRequests:
-    var projectFile = uri.uriToPath()
-    if projectFile notin ls.projectFiles:
-      if uri in ls.openFiles:
-        projectFile = await ls.openFiles[uri].projectFile
+  try:
+    if id in ls.pendingRequests:
+      var projectFile = uri.uriToPath()
+      if projectFile notin ls.projectFiles:
+        if uri in ls.openFiles:
+          projectFile = await ls.openFiles[uri].projectFile
 
-    ls.pendingRequests[id].projectFile = some projectFile
-    ls.sendStatusChanged
+      ls.pendingRequests[id].projectFile = some projectFile
+      ls.sendStatusChanged
+  except CancelledError:
+    discard
+  except CatchableError as e:
+    error "addProjectFileToPendingRequest failed", uri = uri, msg = e.msg
 
 proc requiresDynamicRegistrationForDidChangeConfiguration(ls: LanguageServer): bool =
   ls.lspClientCapabilities.workspace.isSome and

--- a/tests/tmisc.nim
+++ b/tests/tmisc.nim
@@ -47,3 +47,23 @@ suite "Nimlangserver misc":
     check waitFor client.waitForNotificationMessage(
       fmt"Nimsuggest for {hwAbsFile} was stopped because it was idle for too long",
     )
+
+suite "Nimlangserver pending requests":
+  test "cancelled projectFile future does not escape addProjectFileToPendingRequest":
+    # Regression test for #419: addProjectFileToPendingRequest is asyncSpawn'd,
+    # so an escaping CancelledError (nimsuggest restart or $/cancelRequest
+    # cancelling the awaited projectFile future) is re-raised into the event
+    # loop, escapes runForever and hits main's `except Exception: quit(1)`.
+    # The spawned task must swallow cancellation instead of failing.
+    let ls = LanguageServer(serverMode: lsp, transportMode: socket)
+    let uri = "file:///tmp/tpending419.nim"
+    let projectFileFut = newFuture[string]("projectFile")
+    ls.openFiles[uri] = NlsFileInfo(projectFile: projectFileFut)
+    ls.pendingRequests[1'u] = PendingRequest(id: 1, name: "textDocument/definition")
+
+    let fut = ls.addProjectFileToPendingRequest(1'u, uri)
+    projectFileFut.cancelSoon()
+    waitFor sleepAsync(10)
+
+    check fut.finished
+    check fut.completed


### PR DESCRIPTION
## Summary

Fixes #419 — the server exits via `main`'s `except Exception: quit(1)` when a `CancelledError` escapes the `asyncSpawn`'d `addProjectFileToPendingRequest` task.

## Root cause

`addProjectFileToPendingRequest` awaits the file's `projectFile` future, which is routinely cancelled during normal operation (nimsuggest restart, `$/cancelRequest` during rapid editing). The proc is fire-and-forget (`asyncSpawn`, 11 call sites in `routes/lsp.nim`), so the unhandled `CancelledError` is re-raised into the event loop, escapes `runForever`, and `main` treats it as fatal — the server dies cleanly (no crash report) during ordinary editing churn.

## Fix

Guard the spawned task body: swallow cancellation (it only means the request/project resolution is moot), log other `CatchableError`s.

As discussed in #419, the alternative is to let the proc raise and handle it at the call sites — but with 11 spawn sites that either means 11 wrappers or converting the routes to `await` (a behavioral change: requests would block on project-file resolution, which the `asyncSpawn` exists to avoid). Guarding the task body keeps the change in one place; happy to do the call-site refactor as a follow-up if preferred.

## Test

Unit test that seeds a pending request whose `projectFile` future is then cancelled, and asserts the spawned proc's future completes instead of failing. Fails before the fix (future ends in `Cancelled` state, which `asyncSpawn` escalates), passes after; full suite green (46/46).

Also verified against a live editor session: with this fix the server survives nimsuggest crash/cancel churn that previously killed it.
