### PR TITLE
Fix KeyError in removeIdleNimsuggests aborting idle project cleanup

### DIFF
--- a/ls.nim
+++ b/ls.nim
@@ -1308,7 +1308,8 @@ proc removeIdleNimsuggests*(ls: LanguageServer) {.async.} =
     let ns = await project.ns
     for uri in ns.openFiles:
       debug "Removing idle nimsuggest open file", uri = uri
-      await ls.makeIdleFile(ls.openFiles[uri])
+      ls.openFiles.withValue(uri, info):
+        await ls.makeIdleFile(info[])
     project.stop()
     ls.projectFiles.del(project.file)
 

--- a/tests/tmisc.nim
+++ b/tests/tmisc.nim
@@ -47,3 +47,48 @@ suite "Nimlangserver misc":
     check waitFor client.waitForNotificationMessage(
       fmt"Nimsuggest for {hwAbsFile} was stopped because it was idle for too long",
     )
+
+suite "Nimlangserver idle nimsuggest cleanup":
+  let cmdParams = CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
+  let ls = main(cmdParams)
+  let client = newLspSocketClient()
+  waitFor client.connect("localhost", cmdParams.port)
+  client.registerNotification(
+    "window/showMessage", "window/workDoneProgress/create", "workspace/configuration",
+    "extension/statusUpdate", "textDocument/publishDiagnostics", "$/progress",
+  )
+
+  test "idle nimsuggest is removed even when an open file was already evicted":
+    # Regression test for #420: a URI evicted from ls.openFiles while the
+    # nimsuggest still tracks it made removeIdleNimsuggests raise KeyError,
+    # skipping project.stop()/projectFiles.del so the project was re-selected
+    # for removal on every tick.
+    let initParams =
+      LspInitializeParams %* {
+        "processId": %getCurrentProcessId(),
+        "rootUri": fixtureUri("projects/hw/"),
+        "capabilities":
+          {"window": {"workDoneProgress": true}, "workspace": {"configuration": true}},
+      }
+    discard waitFor client.initialize(initParams)
+    let conf = NlsConfig(nimsuggestIdleTimeout: some 1000)
+    ls.workspaceConfiguration.complete(% @[conf])
+    discard waitFor ls.workspaceConfiguration
+
+    let helloWorldFile = "projects/hw/hw.nim"
+    let hwAbsFile = uriToPath(helloWorldFile.fixtureUri())
+    client.notify("textDocument/didOpen", %createDidOpenParams(helloWorldFile))
+    check waitFor client.waitForNotificationMessage(
+      fmt"Nimsuggest initialized for {hwAbsFile}"
+    )
+
+    ls.openFiles.del(helloWorldFile.fixtureUri())
+
+    var removed = false
+    for attempt in 0 ..< 5:
+      waitFor sleepAsync(1100)
+      waitFor ls.removeIdleNimsuggests()
+      if hwAbsFile notin ls.projectFiles:
+        removed = true
+        break
+    check removed


### PR DESCRIPTION
## Summary

Fixes #420 — `removeIdleNimsuggests` raises `KeyError` when an idle nimsuggest still tracks a URI that has already been evicted from `ls.openFiles`, so the idle project is never cleaned up and the log fills with `ERR Error in tick msg="key not found: …"` on every tick.

## Root cause

The cleanup loop indexes `ls.openFiles[uri]` unchecked for every file the nimsuggest has open. If a URI is no longer in `ls.openFiles` (file deleted / tab closed while the nimsuggest still tracks it), the `KeyError` aborts the loop before `project.stop()` and `ls.projectFiles.del(project.file)` run. `tick`'s outer `try/except` swallows the exception, the stale project stays in `ls.projectFiles`, and the next tick repeats the whole sequence indefinitely — the nimsuggest process is also never stopped.

## Fix

Skip evicted URIs with `withValue` so the cleanup sequence always completes.

## Test

Regression test that opens a file, evicts its URI from `ls.openFiles` while the nimsuggest still tracks it, and asserts `removeIdleNimsuggests` still removes the idle project. Fails with `KeyError: key not found: file:///…/hw.nim` before the fix, passes after; full suite green (46/46).
