### PR TITLE
Make markFailed idempotent so one nimsuggest crash restarts once

### DIFF
--- a/suggestapi.nim
+++ b/suggestapi.nim
@@ -261,6 +261,8 @@ proc name*(sug: Suggest): string =
   return sug.qualifiedPath[^1]
 
 proc markFailed(self: Project, errMessage: string) {.raises: [].} =
+  if self.failed:
+    return
   self.failed = true
   self.errorMessage = errMessage
   if self.errorCallback.isSome:

--- a/tests/tsuggestapi.nim
+++ b/tests/tsuggestapi.nim
@@ -1,5 +1,5 @@
 import
-  ../suggestapi, os, std/asyncnet, strutils, chronos, options
+  ../suggestapi, os, std/asyncnet, strutils, chronos, chronos/asyncproc, options
 import unittest2
 
 const inputLine = "def	skProc	hw.a	proc (){.noSideEffect, gcsafe.}	hw/hw.nim	1	5	\"\"	100"
@@ -65,3 +65,31 @@ suite "Nimsuggest tests":
   #     res2 = nimSuggest.chk(helloWorldFile, helloWorldFile)
   #   doAssert res1.waitFor.len == 2
   #   doAssert res2.waitFor.len == 0
+
+suite "Nimsuggest error handling":
+  test "a dying nimsuggest fires the error callback exactly once":
+    # Regression test for #428: markFailed fired errorCallback on every call,
+    # so one crash triggered it once per failure path (closed socket in
+    # processQueue + stderr EOF in logNsError) and the server restarted the
+    # same project twice, concurrently. Suspend the child before issuing a
+    # command so the command is in flight when the process is killed and both
+    # paths run deterministically.
+    let helloWorldFile = getCurrentDir() / "tests/projects/hw/hw.nim"
+    let project = createNimsuggest(helloWorldFile).waitFor
+    let ns = project.ns.waitFor
+    var errorCount = 0
+    project.errorCallback = some(
+      proc(pr: Project) {.gcsafe, raises: [].} =
+        inc errorCount
+    )
+
+    discard project.process.suspend()
+    let fut = ns.def(helloWorldFile, helloWorldFile, 2, 10)
+    waitFor sleepAsync(200)
+    discard project.process.kill()
+
+    expect CatchableError:
+      discard waitFor fut
+    waitFor sleepAsync(300)
+
+    check errorCount == 1


### PR DESCRIPTION
## Summary

Fixes #428 — one nimsuggest crash fires the project's `errorCallback` twice, launching two concurrent restarts of the same project.

## Root cause

`markFailed` sets `self.failed = true` but never checks it, and invokes `errorCallback` unconditionally. A dying nimsuggest runs it from both failure paths: the closed socket in `processQueue` (`content == ""`) and the stderr EOF in `logNsError`. Each firing runs `onErrorCallback` → `createOrRestartNimsuggest`, so the second restart stops and replaces the first *after it already initialized successfully* — extending the window where requests return empty results — and `ls.failTable` double-increments toward `getNimsuggest`'s `MaxFails` give-up threshold (10 becomes effectively 5).

## Fix

Make `markFailed` idempotent — first failure wins. A restarted project is a fresh `Project` object, so `failed` is never reset on the same instance and the early return is safe.

## Test

Suspends a live nimsuggest child, issues a command (so it's in flight), then kills the process — both failure paths run deterministically. Asserts the error callback fires exactly once; before the fix it fires twice (`errorCount was 2`). Full suite green (46/46).
