### PR TITLE
Reset failTable count when a nimsuggest starts successfully

### DIFF
--- a/ls.nim
+++ b/ls.nim
@@ -1103,6 +1103,7 @@ proc createOrRestartNimsuggest*(
         )
       else:
         debug "Nimsuggest initialized successfully", projectFile = projectFile
+        ls.failTable.del(projectFile)
 
         ls.showMessage(fmt "Nimsuggest initialized for {projectFile}", MessageType.Info)
         traceAsyncErrors ls.checkProject(uri)

--- a/tests/tmisc.nim
+++ b/tests/tmisc.nim
@@ -49,13 +49,40 @@ suite "Nimlangserver misc":
     )
 
 suite "Nimlangserver fail count":
+  let cmdParams = CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
+  let ls = main(cmdParams)
+  let client = newLspSocketClient()
+  waitFor client.connect("localhost", cmdParams.port)
+  client.registerNotification(
+    "window/showMessage", "window/workDoneProgress/create", "workspace/configuration",
+    "extension/statusUpdate", "textDocument/publishDiagnostics", "$/progress",
+  )
+
   test "fail count is reset when a nimsuggest starts successfully":
     # ls.failTable only ever increments, so a project that crashes and
     # recovers keeps ratcheting toward MaxFails in getNimsuggest, after which
     # its requests are silently rerouted or dropped for the rest of the
     # session. A successful start must clear the count.
+    let initParams =
+      LspInitializeParams %* {
+        "processId": %getCurrentProcessId(),
+        "rootUri": fixtureUri("projects/hw/"),
+        "capabilities":
+          {"window": {"workDoneProgress": true}, "workspace": {"configuration": true}},
+      }
+    discard waitFor client.initialize(initParams)
     ls.workspaceConfiguration.complete(% @[NlsConfig()])
+    discard waitFor ls.workspaceConfiguration
+
+    let helloWorldFile = "projects/hw/hw.nim"
+    let hwAbsFile = uriToPath(helloWorldFile.fixtureUri())
     ls.failTable[hwAbsFile] = 5
+
+    client.notify("textDocument/didOpen", %createDidOpenParams(helloWorldFile))
+    check waitFor client.waitForNotificationMessage(
+      fmt"Nimsuggest initialized for {hwAbsFile}"
+    )
+
     check hwAbsFile notin ls.failTable
 
 suite "Nimlangserver pending requests":

--- a/tests/tmisc.nim
+++ b/tests/tmisc.nim
@@ -47,3 +47,40 @@ suite "Nimlangserver misc":
     check waitFor client.waitForNotificationMessage(
       fmt"Nimsuggest for {hwAbsFile} was stopped because it was idle for too long",
     )
+
+suite "Nimlangserver fail count":
+  let cmdParams = CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
+  let ls = main(cmdParams)
+  let client = newLspSocketClient()
+  waitFor client.connect("localhost", cmdParams.port)
+  client.registerNotification(
+    "window/showMessage", "window/workDoneProgress/create", "workspace/configuration",
+    "extension/statusUpdate", "textDocument/publishDiagnostics", "$/progress",
+  )
+
+  test "fail count is reset when a nimsuggest starts successfully":
+    # ls.failTable only ever increments, so a project that crashes and
+    # recovers keeps ratcheting toward MaxFails in getNimsuggest, after which
+    # its requests are silently rerouted or dropped for the rest of the
+    # session. A successful start must clear the count.
+    let initParams =
+      LspInitializeParams %* {
+        "processId": %getCurrentProcessId(),
+        "rootUri": fixtureUri("projects/hw/"),
+        "capabilities":
+          {"window": {"workDoneProgress": true}, "workspace": {"configuration": true}},
+      }
+    discard waitFor client.initialize(initParams)
+    ls.workspaceConfiguration.complete(% @[NlsConfig()])
+    discard waitFor ls.workspaceConfiguration
+
+    let helloWorldFile = "projects/hw/hw.nim"
+    let hwAbsFile = uriToPath(helloWorldFile.fixtureUri())
+    ls.failTable[hwAbsFile] = 5
+
+    client.notify("textDocument/didOpen", %createDidOpenParams(helloWorldFile))
+    check waitFor client.waitForNotificationMessage(
+      fmt"Nimsuggest initialized for {hwAbsFile}"
+    )
+
+    check hwAbsFile notin ls.failTable


### PR DESCRIPTION
## Summary

Reset a project's `ls.failTable` count once its nimsuggest initializes successfully. Companion to #428, independent fix.

## Why it matters

`failTable` only ever increments, and `getNimsuggest` stops using a project's nimsuggest once its count reaches `MaxFails = 10`, silently rerouting requests to whatever other instance exists (or returning nil). Because the count never decays, this is a one-way ratchet over the whole session: any 10 crashes — however transient the cause, and regardless of how many successful restarts happened in between — permanently degrade that project until the language server itself is restarted. A crash-looping nimsuggest that later stabilizes (e.g. after the offending code is edited away) stays penalized forever.

Clearing the count on successful initialization makes `MaxFails` mean what the give-up logic needs it to mean: *consecutive failures to come up*, not lifetime crash count.

## Test

Seeds `failTable[project] = 5`, opens a file in the project, waits for "Nimsuggest initialized", and asserts the entry is gone. Fails before the fix (count survives), passes after; full suite green (46/46).
