### PR TITLE
Chore: Add test artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ nimbledeps
 dprint.json
 
 docs/
+
+tests/nimbleDir/
+tests/projects/testproject/
+tests/projects/testrunner/.gitignore
+tests/projects/testrunner/tests/test1
+tests/projects/testrunner/tests/sampletests


### PR DESCRIPTION
This is a microscopic PR that fixes a minor annoyance: after you run tests locally, the test project and binaries are tracked by default.