### PR TITLE
Fix startup latency and nimsuggest spawns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@ nimcache/
 
 *.log
 *.exe
+*.dSYM
 tests/all
+tests/nimbleDir
+tests/projects
 /nimlangserver
 nimble.develop
 nimble.paths

--- a/ls.nim
+++ b/ls.nim
@@ -846,8 +846,9 @@ proc initNimsuggestInstances*(ls: LanguageServer, rootPath: string) {.async.} =
     let nimbleFile = nimbleFiles[0]
     debug "Starting nimble dump for  ", nimbleFile
     let nimbleDumpInfo = await ls.getNimbleDumpInfo(nimbleFile)
-    debug "Finished nimble dump for  ", nimbleFile
     ls.entryPoints = nimbleDumpInfo.getNimbleEntryPoints(rootPath)
+    
+    debug "Finished nimble dump for  ", nimbleFile
     for entryPoint in ls.entryPoints:
       debug "Starting nimsuggest for entry point ", entry = entryPoint
       if entryPoint notin ls.projectFiles:

--- a/ls.nim
+++ b/ls.nim
@@ -163,7 +163,6 @@ type
     inlayHintsRefreshRequest*: Future[JsonNode]
     didChangeConfigurationRegistrationRequest*: Future[JsonNode]
     filesWithDiags*: HashSet[string]
-    nimsuggestInit*: Future[void]
     lastNimsuggest*: Future[Nimsuggest]
     childNimsuggestProcessesStopped*: bool
     isShutdown*: bool
@@ -850,11 +849,13 @@ proc getNimsuggestInner(ls: LanguageServer, uri: string): Future[Nimsuggest] {.a
     else:
       return nil
 
-  # Check multiple times with small delays
+  # Check multiple times with small delays.
+  # Skip entries whose ns is still pending (sentinel from createOrRestartNimsuggest).
   var attempts = 0
   const maxAttempts = 10
   while attempts < maxAttempts:
-    if projectFile in ls.projectFiles:
+    if projectFile in ls.projectFiles and
+        ls.projectFiles[projectFile].ns.finished:
       ls.lastNimsuggest = ls.projectFiles[projectFile].ns
       return await ls.projectFiles[projectFile].ns
 
@@ -914,8 +915,17 @@ proc didOpenFile*(
     debug "Document associated with the following projectFile",
       uri = uri, projectFile = projectFile
     if not ls.projectFiles.hasKey(projectFile):
-      debug "Will create nimsuggest for this file", uri = uri
-      ls.createOrRestartNimsuggest(projectFile, uri)
+      let shouldSpawn = await ls.shouldSpawnNimsuggest()
+      if shouldSpawn:
+        debug "Will create nimsuggest for this file", uri = uri
+        ls.createOrRestartNimsuggest(projectFile, uri)
+      elif ls.projectFiles.len > 0 and uri in ls.openFiles:
+        let reused = ls.projectFiles.keys.toSeq[0]
+        debug "Limit reached in didOpenFile, reusing nimsuggest",
+          uri = uri, reused = reused
+        let f = newFuture[string]("reuse")
+        f.complete(reused)
+        ls.openFiles[uri].projectFile = f
 
     for line in text.splitLines:
       if uri in ls.openFiles:
@@ -1091,6 +1101,12 @@ proc createOrRestartNimsuggest*(
 ) {.gcsafe, raises: [].} =
   try:
     debug "Starting createOrRestartNimsuggest", projectFile = projectFile, uri = uri
+    # Reserve the slot immediately so concurrent shouldSpawnNimsuggest checks see it.
+    # The sentinel has a pending ns future; getNimsuggestInner skips pending entries
+    # and retries until the real project replaces this sentinel.
+    if projectFile notin ls.projectFiles:
+      ls.projectFiles[projectFile] =
+        Project(file: projectFile, ns: newFuture[Nimsuggest]("pending"))
     let
       configuration = ls.getWorkspaceConfiguration().waitFor()
       workingDir = ls.getWorkingDir(projectFile).waitFor()

--- a/ls.nim
+++ b/ls.nim
@@ -282,6 +282,16 @@ proc getNimbleDumpInfo*(
     let workDir =
       if nimbleFile == "": getCurrentDir()
       else: nimbleFile.parentDir
+    
+    let nimbleDirEnv = getEnv("NIMBLE_DIR", "<not set>")
+    let homeEnv = getEnv("HOME", "<not set>")
+    let pathEnv = getEnv("PATH", "<not set>")
+    debug "getNimbleDumpInfo environment",
+      nimbleFile = nimbleFile,
+      workDir = workDir,
+      NIMBLE_DIR = nimbleDirEnv,
+      HOME = homeEnv,
+      PATH = pathEnv
     process = await startProcess(
       "nimble",
       workingDir = workDir,
@@ -291,6 +301,7 @@ proc getNimbleDumpInfo*(
       stdoutHandle = AsyncProcess.Pipe,
     )
     let info = string.fromBytes(process.stdoutStream.read().await)
+    debug "getNimbleDumpInfo result ", info
 
     for line in info.splitLines:
       if line.startsWith("srcDir"):
@@ -833,7 +844,9 @@ proc initNimsuggestInstances*(ls: LanguageServer, rootPath: string) {.async.} =
   let nimbleFiles = walkFiles(rootPath / "*.nimble").toSeq
   if nimbleFiles.len > 0:
     let nimbleFile = nimbleFiles[0]
+    debug "Starting nimble dump for  ", nimbleFile
     let nimbleDumpInfo = await ls.getNimbleDumpInfo(nimbleFile)
+    debug "Finished nimble dump for  ", nimbleFile
     ls.entryPoints = nimbleDumpInfo.getNimbleEntryPoints(rootPath)
     for entryPoint in ls.entryPoints:
       debug "Starting nimsuggest for entry point ", entry = entryPoint
@@ -1183,6 +1196,35 @@ proc onErrorCallback(args: (LanguageServer, string), project: Project) =
       )
       ls.sendStatusChanged()
 
+proc findNimblePaths(fromFile: string): seq[string] =
+  ## Walk up from fromFile's directory looking for nimble.paths.
+  ## Returns the flags it contains (--noNimblePath and --path:... entries)
+  ## with any surrounding quotes stripped, ready to pass directly to nimsuggest.
+  var dir = fromFile.parentDir
+  while dir.len > 0:
+    let pathsFile = dir / "nimble.paths"
+    if pathsFile.fileExists:
+      debug "Found nimble.paths for nimsuggest", path = pathsFile
+      for line in pathsFile.lines:
+        let trimmed = line.strip()
+        if trimmed.len == 0:
+          continue
+        if trimmed.startsWith("--path:"):
+          # nimble.paths wraps paths in quotes: --path:"/foo/bar"
+          # Strip them so the arg is passed cleanly to nimsuggest.
+          let val = trimmed[7 .. ^1]
+          if val.len >= 2 and val[0] == '"' and val[^1] == '"':
+            result.add("--path:" & val[1 .. ^2])
+          else:
+            result.add(trimmed)
+        else:
+          result.add(trimmed)
+      return
+    let parent = dir.parentDir
+    if parent == dir:
+      break
+    dir = parent
+
 proc createOrRestartNimsuggest*(
     ls: LanguageServer, projectFile: string, uri = ""
 ) {.gcsafe, raises: [].} =
@@ -1211,7 +1253,9 @@ proc createOrRestartNimsuggest*(
         ls.sendStatusChanged()
       errorCallback = partial(onErrorCallback, (ls, uri))
 
-    debug "Creating new nimsuggest project", projectFile = projectFile
+    let nimPaths = findNimblePaths(projectFile)
+    debug "Creating new nimsuggest project",
+      projectFile = projectFile, nimPathCount = nimPaths.len
 
     let projectNext = waitFor createNimsuggest(
       projectFile,
@@ -1223,6 +1267,7 @@ proc createOrRestartNimsuggest*(
       workingDir,
       configuration.logNimsuggest.get(false),
       configuration.exceptionHintsEnabled,
+      nimPaths,
     )
 
     if projectFile in ls.projectFiles:

--- a/ls.nim
+++ b/ls.nim
@@ -1274,6 +1274,7 @@ proc checkFile*(ls: LanguageServer, uri: string): Future[void] {.async.} =
 
   let ns = await ls.tryGetNimsuggest(uri)
   if ns.isSome:
+    discard await ns.get().changed(path, ls.uriToStash(uri))
     let diagnostics = ns.get().chkFile(path, ls.uriToStash(uri)).await()
     ls.progress(token, "end")
     ls.sendDiagnostics(diagnostics, path)

--- a/ls.nim
+++ b/ls.nim
@@ -786,6 +786,16 @@ proc createOrRestartNimsuggest*(
   ls: LanguageServer, projectFile: string, uri = ""
 ) {.gcsafe, raises: [].}
 
+proc shouldSpawnNimsuggest*(ls: LanguageServer): Future[bool] {.async.} =
+  # Count ALL projectFiles entries (including projects still starting), not just
+  # finished ones — otherwise concurrent didOpen tasks all see count=0 and all spawn.
+  let nsCount = ls.projectFiles.len
+  let conf = await ls.getWorkspaceConfiguration
+  let maxNimsuggestProcesses = conf.maxNimsuggestProcesses.get(NIM_MAX_NS_PROCESSES)
+  result = maxNimsuggestProcesses == 0 or nsCount < maxNimsuggestProcesses
+  debug "shouldSpawnNimsuggest",
+    result = result, nsCount = nsCount, maxNimsuggestProcesses = maxNimsuggestProcesses
+
 proc initNimsuggestInstances*(ls: LanguageServer, rootPath: string) {.async.} =
   if rootPath == "":
     return
@@ -798,17 +808,26 @@ proc initNimsuggestInstances*(ls: LanguageServer, rootPath: string) {.async.} =
     for entryPoint in ls.entryPoints:
       debug "Starting nimsuggest for entry point ", entry = entryPoint
       if entryPoint notin ls.projectFiles:
-        ls.createOrRestartNimsuggest(entryPoint)
+        let shouldSpawn = await ls.shouldSpawnNimsuggest()
+        if shouldSpawn:
+          ls.createOrRestartNimsuggest(entryPoint)
+        else:
+          debug "Limit reached, skipping entry point", entryPoint = entryPoint
+          break
 
 proc getNimsuggestInner(ls: LanguageServer, uri: string): Future[Nimsuggest] {.async.} =
   assert uri in ls.openFiles, "File not open"
 
   let projectFile = await ls.openFiles[uri].projectFile
   if not ls.projectFiles.hasKey(projectFile):
-    debug "Creating new nimsuggest instance", uri = uri, projectFile = projectFile
-    ls.createOrRestartNimsuggest(projectFile, uri)
-    # Wait a bit to allow nimsuggest to start
-    await sleepAsync(10)
+    let shouldSpawn = await ls.shouldSpawnNimsuggest()
+    if shouldSpawn:
+      debug "Creating new nimsuggest instance", uri = uri, projectFile = projectFile
+      ls.createOrRestartNimsuggest(projectFile, uri)
+      # Wait a bit to allow nimsuggest to start
+      await sleepAsync(10)
+    else:
+      debug "Limit reached, reusing existing nimsuggest", uri = uri
 
   const MaxFails = 10
   if projectFile in ls.failTable and ls.failTable[projectFile] >= MaxFails:
@@ -1200,14 +1219,6 @@ proc stopNimsuggestProcesses*(ls: LanguageServer) {.async.} =
 proc stopNimsuggestProcessesP*(ls: LanguageServer) =
   waitFor stopNimsuggestProcesses(ls)
 
-proc shouldSpawnNimsuggest*(ls: LanguageServer): Future[bool] {.async.} =
-  let nsCount = ls.getLspStatus().nimsuggestInstances.len
-  let conf = await ls.getWorkspaceConfiguration
-  let maxNimsuggestProcesses = conf.maxNimsuggestProcesses.get(NIM_MAX_NS_PROCESSES)
-  result = maxNimsuggestProcesses == 0 or nsCount < maxNimsuggestProcesses
-  debug "shouldSpawnNimsuggest",
-    result = result, nsCount = nsCount, maxNimsuggestProcesses = maxNimsuggestProcesses
-
 proc getProjectFile*(fileUri: string, ls: LanguageServer): Future[string] {.async.} =
   let
     rootPath =
@@ -1230,6 +1241,11 @@ proc getProjectFile*(fileUri: string, ls: LanguageServer): Future[string] {.asyn
       if fileExists(result):
         trace "getProjectFile?",
           project = result, uri = fileUri, matchedRegex = mapping.fileRegex
+        let shouldSpawn = await ls.shouldSpawnNimsuggest()
+        if not shouldSpawn:
+          result = ls.projectFiles.keys.toSeq[0]
+          debug "Reached the maximum instances of nimsuggest (mapping), reusing first instance",
+            project = result
         return result
     else:
       trace "getProjectFile does not match",

--- a/ls.nim
+++ b/ls.nim
@@ -877,6 +877,9 @@ proc checkFile*(ls: LanguageServer, uri: string): Future[void] {.raises: [], gcs
 proc didCloseFile*(ls: LanguageServer, uri: string): Future[void] {.async.} =
   debug "Closed the following document:", uri = uri
 
+  if uri notin ls.openFiles:
+    return
+
   if ls.openFiles[uri].changed:
     # check the file if it is closed but not saved.
     traceAsyncErrors ls.checkFile(uri)
@@ -892,10 +895,62 @@ proc makeIdleFile*(ls: LanguageServer, file: NlsFileInfo): Future[void] {.async.
 
 proc getProjectFile*(fileUri: string, ls: LanguageServer): Future[string] {.async.}
 
+proc didRenameFile*(
+    ls: LanguageServer, oldUri, newUri: string
+): Future[void] {.async.} =
+  debug "File renamed", oldUri = oldUri, newUri = newUri
+
+  # Move the stash file so any pending content checks use the right path
+  let oldStash = ls.uriStorageLocation(oldUri)
+  let newStash = ls.uriStorageLocation(newUri)
+  if oldStash.fileExists:
+    try:
+      moveFile(oldStash, newStash)
+    except Exception as e:
+      debug "Failed to move stash file on rename", oldStash = oldStash, newStash = newStash, msg = e.msg
+
+  # If a .nimble file was renamed, invalidate its dump cache entry
+  let oldPath = uriToPath(oldUri)
+  if oldPath.endsWith(".nimble"):
+    ls.nimDumpCache.del(oldPath)
+    ls.nimDumpCache.del(uriToPath(newUri))
+
+  # If the file is currently open, migrate its entry to the new URI
+  if oldUri in ls.openFiles:
+    let oldInfo = ls.openFiles[oldUri]
+    let oldProjectFile = await oldInfo.projectFile
+    let newProjectFile = await getProjectFile(uriToPath(newUri), ls)
+
+    let newFut = newFuture[string]("rename")
+    newFut.complete(newProjectFile)
+    ls.openFiles[newUri] = NlsFileInfo(
+      projectFile: newFut,
+      changed: oldInfo.changed,
+      fingerTable: oldInfo.fingerTable,
+      textDocument: TextDocumentItem(
+        uri: newUri,
+        languageId: oldInfo.textDocument.languageId,
+        version: oldInfo.textDocument.version,
+        text: oldInfo.textDocument.text,
+      ),
+    )
+    ls.openFiles.del(oldUri)
+
+    # If the file moved to a different project, ensure nimsuggest is running for it
+    if newProjectFile != oldProjectFile and newProjectFile notin ls.projectFiles:
+      let shouldSpawn = await ls.shouldSpawnNimsuggest()
+      if shouldSpawn:
+        ls.createOrRestartNimsuggest(newProjectFile, newUri)
+
 proc didOpenFile*(
     ls: LanguageServer, textDocument: TextDocumentItem
 ): Future[void] {.async.} =
   with textDocument:
+    if uri in ls.openFiles:
+      # Already tracked — this didOpen arrived after a didRenameFiles that
+      # already migrated the entry to this URI. Nothing to do.
+      debug "didOpenFile: URI already tracked (post-rename), skipping", uri = uri
+      return
     debug "New document opened for URI:", uri = uri
     let
       file = open(ls.uriStorageLocation(uri), fmWrite)

--- a/ls.nim
+++ b/ls.nim
@@ -277,9 +277,16 @@ proc getNimbleDumpInfo*(
     return ls.nimDumpCache.getOrDefault(nimbleFile)
   var process: AsyncProcessRef
   try:
+    # nimble dump expects no file argument — it reads the .nimble in its CWD.
+    # Passing an absolute path as an argument causes nimble to mangle it
+    # (prepend CWD, strip leading '/') and fail silently with empty output.
+    let workDir =
+      if nimbleFile == "": getCurrentDir()
+      else: nimbleFile.parentDir
     process = await startProcess(
       "nimble",
-      arguments = @["dump", nimbleFile],
+      workingDir = workDir,
+      arguments = @["dump"],
       options = {UsePath},
       stderrHandle = AsyncProcess.Pipe,
       stdoutHandle = AsyncProcess.Pipe,
@@ -299,9 +306,13 @@ proc getNimbleDumpInfo*(
         result.entryPoints =
           line[(1 + line.find '"') ..^ 2].split(',').mapIt(it.strip(chars = {' ', '"'}))
 
+    # Cache under the resolved path AND under "" so that repeated empty-string
+    # calls don't re-run the SAT solver on every nimsuggest spawn.
     var nimbleFile = nimbleFile
-    if nimbleFile == "" and result.nimblePath.isSome:
-      nimbleFile = result.nimblePath.get
+    if nimbleFile == "":
+      ls.nimDumpCache[""] = result
+      if result.nimblePath.isSome:
+        nimbleFile = result.nimblePath.get
     if nimbleFile != "":
       ls.nimDumpCache[nimbleFile] = result
   except OSError, IOError:

--- a/ls.nim
+++ b/ls.nim
@@ -361,6 +361,26 @@ proc getAndWaitForWorkspaceConfiguration*(
     error "Failed to get workspace configuration", error = ex.msg
     writeStackTrace(ex)
 
+const CONFIG_WAIT_TIMEOUT_MS = 30_000
+const CONFIG_WAIT_POLL_MS = 50
+
+proc waitForWorkspaceConfiguration*(ls: LanguageServer): Future[NlsConfig] {.async.} =
+  ## Waits for workspace configuration with a 30-second fallback to defaults.
+  ## Safe to call from any async context; idempotent once config has arrived.
+  ## Polls rather than awaiting the shared future directly to avoid cancelling it.
+  if ls.workspaceConfiguration.finished:
+    return await ls.getWorkspaceConfiguration()
+  debug "Waiting for workspace configuration from client"
+  var elapsed = 0
+  while not ls.workspaceConfiguration.finished and elapsed < CONFIG_WAIT_TIMEOUT_MS:
+    await sleepAsync(CONFIG_WAIT_POLL_MS)
+    elapsed += CONFIG_WAIT_POLL_MS
+  if ls.workspaceConfiguration.finished:
+    debug "Workspace configuration received"
+  else:
+    warn "Workspace configuration not received within timeout, proceeding with defaults"
+  return await ls.getWorkspaceConfiguration()
+
 proc showMessage*(
     ls: LanguageServer, message: string, typ: MessageType
 ) {.raises: [].} =
@@ -951,6 +971,18 @@ proc didOpenFile*(
       # already migrated the entry to this URI. Nothing to do.
       debug "didOpenFile: URI already tracked (post-rename), skipping", uri = uri
       return
+
+    # Wait for config before getProjectFile so projectMapping and
+    # maxNimsuggestProcesses are available when the project file is resolved.
+    discard await ls.waitForWorkspaceConfiguration()
+
+    # Re-check after the await: a concurrent didOpen or didRenameFile may have
+    # inserted this URI while we were waiting for configuration.
+    if uri in ls.openFiles:
+      debug "didOpenFile: URI tracked after config wait (concurrent open), skipping",
+        uri = uri
+      return
+
     debug "New document opened for URI:", uri = uri
     let
       file = open(ls.uriStorageLocation(uri), fmWrite)

--- a/nimlangserver.nim
+++ b/nimlangserver.nim
@@ -96,6 +96,7 @@ proc registerLspRoutes(srv: RpcSocketServer, ls: LanguageServer) =
   srv.register("textDocument/didOpen", wrapRpc(partial(lsp.didOpen, ls)))
   srv.register("textDocument/didSave", wrapRpc(partial(lsp.didSave, ls)))
   srv.register("textDocument/didClose", wrapRpc(partial(lsp.didClose, ls)))
+  srv.register("workspace/didRenameFiles", wrapRpc(partial(lsp.didRenameFiles, ls)))
   srv.register(
     "workspace/didChangeConfiguration", wrapRpc(partial(lsp.didChangeConfiguration, ls))
   )

--- a/protocol/types.nim
+++ b/protocol/types.nim
@@ -640,10 +640,17 @@ type
 
   FileOperationFilter* = ref object of RootObj
     scheme*: Option[string]
-    pattern: FileOperationPattern
+    pattern*: FileOperationPattern
 
   FileOperationRegistrationOptions* = ref object of RootObj
     filters*: seq[FileOperationFilter]
+
+  FileRename* = ref object of RootObj
+    oldUri*: string
+    newUri*: string
+
+  RenameFilesParams* = ref object of RootObj
+    files*: seq[FileRename]
 
   ServerCapabilities_workspace_fileOperations* = ref object of RootObj
     didCreate*: Option[FileOperationRegistrationOptions]
@@ -655,7 +662,7 @@ type
 
   ServerCapabilities_workspace* = ref object of RootObj
     workspaceFolders*: Option[WorkspaceFoldersServerCapabilities]
-    #!!!!!!!fileOperations*: Option[ServerCapabilities_workspace_fileOperations]
+    fileOperations*: Option[ServerCapabilities_workspace_fileOperations]
 
   TextDocumentRegistrationOptions* = ref object of RootObj
     documentSelector*: OptionalSeq[DocumentFilter]

--- a/routes/lsp.nim
+++ b/routes/lsp.nim
@@ -107,12 +107,10 @@ proc initialize*(
 
   debug "Initialize completed. Trying to start nimsuggest instances"
 
-  let
-    ls = p.ls
-    rootPath = ls.lspInitializeParams.getRootPath
-
+  let ls = p.ls
   ls.lspServerCapabilities = result.capabilities
-  ls.nimSuggestInit = ls.initNimsuggestInstances(rootPath)
+  let rootPath = ls.lspInitializeParams.getRootPath
+  await ls.initNimsuggestInstances(rootPath)
 
 proc toCompletionItem(suggest: Suggest): CompletionItem =
   with suggest:

--- a/routes/lsp.nim
+++ b/routes/lsp.nim
@@ -817,6 +817,15 @@ proc exit*(
 proc startNimbleProcess(
     ls: LanguageServer, args: seq[string]
 ): Future[AsyncProcessRef] {.async.} =
+  let nimbleDirEnv = getEnv("NIMBLE_DIR", "<not set>")
+  let homeEnv = getEnv("HOME", "<not set>")
+  let pathEnv = getEnv("PATH", "<not set>")
+  debug "startNimbleProcess environment",
+    args = args,
+    workingDir = ls.lspInitializeParams.getRootPath,
+    NIMBLE_DIR = nimbleDirEnv,
+    HOME = homeEnv,
+    PATH = pathEnv
   await startProcess(
     "nimble",
     arguments = args,
@@ -829,6 +838,9 @@ proc startNimbleProcess(
 proc tasks*(ls: LanguageServer, conf: JsonNode): Future[seq[NimbleTask]] {.async.} =
   let rootPath: string = ls.lspInitializeParams.getRootPath
   debug "Received tasks ", rootPath = rootPath
+  debug "tasks: deleting NIMBLE_DIR before nimble tasks",
+    NIMBLE_DIR_before = getEnv("NIMBLE_DIR", "<not set>"),
+    HOME = getEnv("HOME", "<not set>")
   delEnv "NIMBLE_DIR"
   let process = await ls.startNimbleProcess(@["tasks"])
   let res =

--- a/routes/lsp.nim
+++ b/routes/lsp.nim
@@ -1004,7 +1004,6 @@ proc didClose*(
 proc didOpen*(
     ls: LanguageServer, params: DidOpenTextDocumentParams
 ): Future[void] {.async.} =
-  await ls.nimsuggestInit
   await ls.didOpenFile(params.textDocument)
 
 proc didChangeConfiguration*(

--- a/routes/lsp.nim
+++ b/routes/lsp.nim
@@ -73,7 +73,21 @@ proc initialize*(
       hoverProvider: some(true),
       workspace: some(
         ServerCapabilities_workspace(
-          workspaceFolders: some(WorkspaceFoldersServerCapabilities())
+          workspaceFolders: some(WorkspaceFoldersServerCapabilities()),
+          fileOperations: some(
+            ServerCapabilities_workspace_fileOperations(
+              didRename: some(
+                FileOperationRegistrationOptions(
+                  filters: @[
+                    FileOperationFilter(
+                      scheme: some("file"),
+                      pattern: FileOperationPattern(glob: "**/*.nim"),
+                    )
+                  ]
+                )
+              )
+            )
+          ),
         )
       ),
       completionProvider:
@@ -1003,6 +1017,12 @@ proc didOpen*(
     ls: LanguageServer, params: DidOpenTextDocumentParams
 ): Future[void] {.async.} =
   await ls.didOpenFile(params.textDocument)
+
+proc didRenameFiles*(
+    ls: LanguageServer, params: RenameFilesParams
+): Future[void] {.async.} =
+  for rename in params.files:
+    await ls.didRenameFile(rename.oldUri, rename.newUri)
 
 proc didChangeConfiguration*(
     ls: LanguageServer, conf: JsonNode

--- a/routes/lsp.nim
+++ b/routes/lsp.nim
@@ -119,12 +119,10 @@ proc initialize*(
     if docCaps.rename.isSome and docCaps.rename.get().prepareSupport.get(false):
       result.capabilities.renameProvider = %*{"prepareProvider": true}
 
-  debug "Initialize completed. Trying to start nimsuggest instances"
+  debug "Initialize completed. Nimsuggest instances will start after configuration arrives."
 
   let ls = p.ls
   ls.lspServerCapabilities = result.capabilities
-  let rootPath = ls.lspInitializeParams.getRootPath
-  await ls.initNimsuggestInstances(rootPath)
 
 proc toCompletionItem(suggest: Suggest): CompletionItem =
   with suggest:
@@ -913,6 +911,9 @@ proc initialized*(ls: LanguageServer, _: JsonNode): Future[void] {.async.} =
   debug "Client initialized."
   maybeRegisterCapabilityDidChangeConfiguration(ls)
   maybeRequestConfigurationFromClient(ls)
+  discard await ls.waitForWorkspaceConfiguration()
+  let rootPath = ls.lspInitializeParams.getRootPath
+  await ls.initNimsuggestInstances(rootPath)
 
 proc cancelRequest*(ls: LanguageServer, params: CancelParams): Future[void] {.async.} =
   if params.id.isSome:

--- a/routes/mcp.nim
+++ b/routes/mcp.nim
@@ -506,7 +506,7 @@ proc initialize*(
     rootPath = getCurrentDir().pathToUri.uriToPath
 
   ls.mcpServerCapabilities = result.capabilities
-  ls.nimSuggestInit = ls.initNimsuggestInstances(rootPath)
+  await ls.initNimsuggestInstances(rootPath)
 
 proc listTools*(
     ls: LanguageServer, params: McpListToolsParams
@@ -528,8 +528,6 @@ proc callTool*(
 ): Future[McpCallToolResult] {.async.} =
   debug "Call tool received...", name = params.name
 
-  await ls.nimsuggestInit
-  
   case params.name
   of "nimFindReferences":
     await callNimFindReferences(ls, params)

--- a/suggestapi.nim
+++ b/suggestapi.nim
@@ -345,6 +345,7 @@ proc createNimsuggest*(
     workingDir = getCurrentDir(),
     enableLog: bool = false,
     enableExceptionInlayHints: bool = false,
+    nimPaths: seq[string] = @[],
 ): Future[Project] {.async.} =
   result = Project(file: root)
   result.ns = newFuture[NimSuggest]()
@@ -387,8 +388,12 @@ proc createNimsuggest*(
         args.add("--exceptionInlayHints:on")
       else:
         args.add("--exceptionInlayHints:off")
+    for p in nimPaths:
+      args.add(p)
+    debug "Nimsuggest nim paths", nimPaths = nimPaths
     result.process = await startProcess(
       nimsuggestPath,
+      workingDir = workingDir,
       arguments = args,
       options = {UsePath},
       stdoutHandle = AsyncProcess.Pipe,

--- a/tests/lspsocketclient.nim
+++ b/tests/lspsocketclient.nim
@@ -26,6 +26,10 @@ proc newLspSocketClient*(): LspSocketClient =
   result.notifications = newTable[string, NotificationRpc]()
   result.calls = newTable[string, seq[JsonNode]]()
   result.responses = newTable[int, Future[JsonNode]]()
+  # Default handler: respond to workspace/configuration requests with empty config.
+  # Without this the server's workspaceConfiguration future never completes.
+  result.routes["workspace/configuration"] = proc(params: JsonNode): Future[JsonNode] {.async.} =
+    return newJArray()
 
 method call*(
     client: LspSocketClient, name: string, params: JsonNode
@@ -66,12 +70,18 @@ proc processMessage(client: LspSocketClient, msg: string) {.raises: [].} =
     if "method" in serverReq:
       let meth = serverReq["method"].jsonTo(string)
       debug "[Process Data Loop ]", meth = meth
-      if meth in client.notifications:
-        asyncSpawn client.notifications[meth](serverReq["params"])
-      elif meth in client.routes:
-        asyncSpawn runRpc(client, client.routes[meth], serverReq)
+      if "id" in serverReq:
+        # Server-to-client request: needs a response via client.routes
+        if meth in client.routes:
+          asyncSpawn runRpc(client, client.routes[meth], serverReq)
+        else:
+          error "Route not implemented ", meth = meth
       else:
-        error "Method not implemented ", meth = meth
+        # Server-to-client notification: no response needed
+        if meth in client.notifications:
+          asyncSpawn client.notifications[meth](serverReq["params"])
+        else:
+          error "Method not implemented ", meth = meth
     elif "id" in serverReq: #Response here
       let id = serverReq["id"].jsonTo(int)
       client.responses[id].complete(serverReq["result"])

--- a/tests/textensions.nim
+++ b/tests/textensions.nim
@@ -28,6 +28,7 @@ suite "Nimlangserver extensions":
           {"window": {"workDoneProgress": true}, "workspace": {"configuration": true}},
       }
     let initializeResult = waitFor client.initialize(initParams)
+    ls.workspaceConfiguration.complete(% @[NlsConfig()])
 
     check initializeResult.capabilities.textDocumentSync.isSome
 
@@ -35,7 +36,7 @@ suite "Nimlangserver extensions":
     let helloWorldFile = "projects/hw/hw.nim"
     let hwAbsFile = uriToPath(helloWorldFile.fixtureUri())
     client.notify("textDocument/didOpen", %createDidOpenParams(helloWorldFile))
-    
+
     check waitFor client.waitForNotificationMessage(
       fmt"Nimsuggest initialized for {hwAbsFile}",
     )

--- a/tests/tnimlangserver.nim
+++ b/tests/tnimlangserver.nim
@@ -118,6 +118,9 @@ suite "LSP features":
   let didOpenParams = createDidOpenParams("projects/hw/hw.nim")
 
   client.notify("textDocument/didOpen", %didOpenParams)
+  discard waitFor client.waitForNotificationMessage(
+    fmt"Nimsuggest initialized for {uriToPath(helloWorldUri)}",
+  )
 
   test "Sending hover.":
     let

--- a/tests/tprojectsetup.nim
+++ b/tests/tprojectsetup.nim
@@ -34,7 +34,8 @@ suite "nimble setup":
           {"window": {"workDoneProgress": true}, "workspace": {"configuration": true}},
       }
     discard waitFor client.initialize(initParams)
-   
+    client.notify("initialized", newJObject())
+
     check waitFor client.waitForNotificationMessage(
       fmt"Nimsuggest initialized for {entryPoint}",
     )


### PR DESCRIPTION
# Fix startup latency and nimsuggest spawn race conditions

### Background

Opening VS Code with a Nim project took **1+ minute** before hover, completions, and hints became usable and often spawned the wrong number of nimsuggest instances.  Hover, completions and inlays would then often break during use.

---

### Problem 1: nimsuggest spawned before VS Code config arrived

**Symptom**: `projectMapping` and `maxNimsuggestProcesses` were always at their defaults when nimsuggest was first spawned, so per-project routing rules were never applied on startup.

**Root cause**: `initNimsuggestInstances` was called inside `initialize` (which returns before the client sends `workspace/configuration`). The config response arrives asynchronously, after the round-trip to the client.

**Fix**: Moved `initNimsuggestInstances` to the `initialized` handler. Added `waitForWorkspaceConfiguration()` — a polling loop (50ms intervals, 30s timeout) that waits for the shared config future without cancelling it. Called in both `initialized` and `didOpenFile` before any project-file or spawn decision is made. The previous `await ls.nimsuggestInit` in `didOpen` was removed along with the now-redundant `nimsuggestInit` field.

---

### Problem 2: `maxNimsuggestProcesses` limit not enforced at spawn time

**Symptom**: More nimsuggest processes were spawned than `maxNimsuggestProcesses` allowed, consuming memory and defeating the cap.

**Root cause**: `shouldSpawnNimsuggest` counted only *finished* `projectFiles` entries. Concurrent `didOpen` tasks all saw a count of 0 and each independently decided to spawn, racing past the limit before any of them completed.

**Fix**: Changed `shouldSpawnNimsuggest` to count `ls.projectFiles.len` (all entries, including pending ones). `createOrRestartNimsuggest` now inserts a sentinel entry with a pending `ns` future *before* doing any async work, so subsequent concurrent calls immediately see the slot as occupied. `getNimsuggestInner` was updated to skip pending sentinel entries and retry. The limit is now checked at all three spawn sites: `initNimsuggestInstances`, `getNimsuggestInner`, and `didOpenFile`.

---

### Problem 3: nimsuggest imports broken

**Symptom**: imports sometimes showed "cannot open file" in nimsuggest diagnostics. Even after fixing the SAT solver path, nimsuggest's internal Nim compiler called nimble to resolve every import.

**Root cause**: Nimsuggest was spawned without `--path:` flags, so its compiler had no knowledge of where dependencies lived. It fell back to calling nimble (and thus re-triggering the SAT solver) on every import resolution.

**Fix**:
- Added `findNimblePaths(fromFile)` in `ls.nim`: walks up the directory tree from the project file, finds the nearest `nimble.paths` (generated by `nimble setup`), parses each line, and strips surrounding quotes from `--path:"..."` entries.
- `createOrRestartNimsuggest` calls `findNimblePaths` and logs `nimPathCount=`.
- `createNimsuggest` in `suggestapi.nim` gains a `nimPaths: seq[string]` parameter; entries are appended to nimsuggest's argument list before spawn.
- `startProcess` for nimsuggest now passes `workingDir` so the Nim compiler finds `config.nims` in the project root.

Result: nimsuggest receives `--noNimblePath --path:...` at startup and resolves imports directly without calling nimble.

---

### Problem 4: hints/hover broken after moving a `.nim` file in VS Code

**Symptom**: After using VS Code's file explorer to rename or move a `.nim` file, hover and diagnostics stopped working in the new location.

**Root cause**: No handler existed for `workspace/didRenameFiles`. The server kept the old URI in `openFiles`, the stash file stayed at the old path, and `didOpenFile` for the new URI created a duplicate entry or errored on a missing key.

**Fix**:
- Added `FileRename` and `RenameFilesParams` types to `protocol/types.nim`.
- Uncommented the `fileOperations` field in `ServerCapabilities_workspace` and advertised `didRename` capability for `**/*.nim` in the `initialize` response.
- Registered `workspace/didRenameFiles` in `nimlangserver.nim`.
- Implemented `didRenameFile` in `ls.nim`: moves the stash file, invalidates `nimDumpCache` if a `.nimble` was renamed, migrates the `openFiles` entry to the new URI, and spawns nimsuggest for the new project if the file crossed a project boundary.
- Added early-return guards in `didCloseFile` and `didOpenFile` to prevent `KeyError` / double-insertion when a rename races with a subsequent `didOpen`.

---

### Problem 5: `checkFile` sent stale on-disk content to nimsuggest

**Symptom**: Diagnostics reflected the saved file, not unsaved edits.

**Root cause**: `checkFile` called `chkFile` without first calling `changed()`, so nimsuggest re-read the on-disk file rather than the stash containing the current buffer content.

**Fix**: Added `discard await ns.get().changed(path, ls.uriToStash(uri))` before `chkFile` in `checkFile`.

---

### Problem 6: `nimble dump` invoked with wrong working directory / argument

**Root cause** (separate from Problem 1): The original call was `nimble dump <absolute-path>`. Nimble treats its argument as a relative path and prepends CWD, mangling the absolute path and producing empty output for the cache.

**Fix**: `getNimbleDumpInfo` now sets `workingDir = nimbleFile.parentDir` and passes no file argument. The result is also cached under the empty-string key so repeated calls with `nimbleFile = ""` don't re-run the solver.

---

### Debug instrumentation added

Environment variables (`HOME`, `PATH`, `NIMBLE_DIR`) are logged before every nimble invocation — in `getNimbleDumpInfo`, `startNimbleProcess`, and the `tasks` handler — so that traces in the VS Code LSP log immediately reveal which binary is being resolved and whether the environment is correct.

---

### What was not fixed here

UPon opening VS Code with a Nim project, one reason for the large amount of time and high CPU usage was caused by the nim vs-code extension starting up a `nimble dump` process which was not needed by this LSP code and also had no path or environment information passed in, so it fell back on its SAT solver which blocked the thread until it had completed.  This is fixed in the pull request https://github.com/nim-lang/vscode-nim/pull/185 for the VS Code extension.
