### PR TITLE
CI: Add cache_nonce env var, fix matrix.target.os key, do not cache ~/.cache/nim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      cache_nonce: v1 # bump to force reset cache
     steps:
       - uses: actions/checkout@v6
       - name: Setup Nimble
@@ -30,10 +31,9 @@ jobs:
         with:
           path: |
             ~/.nimble
-            ~/.cache/nim
-          key: ${{ matrix.target.os }}-${{ env.cache_nonce }}-${{ hashFiles('**/nimble.lock') }}
+          key: ${{ runner.os }}-nimble-${{ env.cache_nonce }}-${{ hashFiles('**/nimble.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache_nonce }}-
+            ${{ runner.os }}-nimble-${{ env.cache_nonce }}-
 
       - name: Install dependencies
         shell: bash


### PR DESCRIPTION
1. cache_nonce was not defined in ENV so the value would always be undefined.
2. matrix.target.os replaced with runner.os so that the key and restore key match.
3. caching ~/.cache/nim seems dangerous given that Nim 2.4 stores incremental compilation results there.