### PR TITLE
Avoid some dangling nimsuggests

### DIFF
--- a/ls.nim
+++ b/ls.nim
@@ -167,6 +167,7 @@ type
     nimsuggestInit*: Future[void]
     lastNimsuggest*: Future[Nimsuggest]
     childNimsuggestProcessesStopped*: bool
+    startingNimsuggests*: seq[AsyncProcessRef]
     isShutdown*: bool
     storageDir*: string
     cmdLineClientProcessId*: Option[int]
@@ -1074,6 +1075,10 @@ proc onErrorCallback(args: (LanguageServer, string), project: Project) =
 proc createOrRestartNimsuggest*(
     ls: LanguageServer, projectFile: string, uri = ""
 ) {.gcsafe, raises: [].} =
+  if ls.childNimsuggestProcessesStopped:
+    debug "Not starting nimsuggest, the server is shutting down",
+      projectFile = projectFile
+    return
   try:
     debug "Starting createOrRestartNimsuggest", projectFile = projectFile, uri = uri
     let
@@ -1095,6 +1100,9 @@ proc createOrRestartNimsuggest*(
 
     debug "Creating new nimsuggest project", projectFile = projectFile
 
+    let onNimsuggestSpawn = proc(process: AsyncProcessRef) {.gcsafe, raises: [].} =
+      ls.startingNimsuggests.add process
+
     let projectFut = createNimsuggest(
       projectFile,
       nimsuggestPath,
@@ -1105,6 +1113,7 @@ proc createOrRestartNimsuggest*(
       workingDir,
       configuration.logNimsuggest.get(false),
       configuration.exceptionHintsEnabled,
+      onNimsuggestSpawn,
     )
     if not waitFor chronos.withTimeout(
       projectFut, chronos.milliseconds(NIMSUGGEST_STARTUP_TIMEOUT)
@@ -1113,6 +1122,15 @@ proc createOrRestartNimsuggest*(
       return
 
     let projectNext = waitFor projectFut
+    ls.startingNimsuggests.keepItIf(it != projectNext.process)
+
+    if ls.childNimsuggestProcessesStopped:
+      debug "Discarding the nimsuggest started while shutting down",
+        projectFile = projectFile
+      if not projectNext.process.isNil:
+        waitFor shutdownChildProcess(projectNext.process)
+      return
+
     if projectFile in ls.projectFiles:
       var project = ls.projectFiles[projectFile]
       project.stop()
@@ -1212,13 +1230,18 @@ proc getCharacter*(
     return none(int)
 
 proc stopNimsuggestProcesses*(ls: LanguageServer) {.async.} =
-  if not ls.childNimsuggestProcessesStopped:
-    debug "stopping child nimsuggest processes"
-    ls.childNimsuggestProcessesStopped = true
-    for project in ls.projectFiles.values:
-      project.stop()
-  else:
-    debug "child nimsuggest processes already stopped: CHECK!"
+  debug "stopping child nimsuggest processes"
+  ls.childNimsuggestProcessesStopped = true
+
+  var shutdowns: seq[Future[void]]
+  for project in ls.projectFiles.values:
+    if not project.process.isNil:
+      shutdowns.add shutdownChildProcess(project.process)
+  for process in ls.startingNimsuggests:
+    shutdowns.add shutdownChildProcess(process)
+  ls.projectFiles.clear()
+  ls.startingNimsuggests.setLen(0)
+  await allFutures(shutdowns)
 
 proc stopNimsuggestProcessesP*(ls: LanguageServer) =
   waitFor stopNimsuggestProcesses(ls)

--- a/suggestapi.nim
+++ b/suggestapi.nim
@@ -346,6 +346,7 @@ proc createNimsuggest*(
     workingDir = getCurrentDir(),
     enableLog: bool = false,
     enableExceptionInlayHints: bool = false,
+    onProcessStart: proc(process: AsyncProcessRef) {.gcsafe, raises: [].} = nil,
 ): Future[Project] {.async.} =
   result = Project(file: root)
   result.ns = newFuture[NimSuggest]()
@@ -396,6 +397,8 @@ proc createNimsuggest*(
       stderrHandle = AsyncProcess.Pipe,
     )
     debug "Nimsuggest started with args", args = args
+    if not onProcessStart.isNil:
+      onProcessStart(result.process)
     asyncSpawn logNsError(result)
     let portLine = await result.process.stdoutStream.readLine(sep = "\n")
     debug "Nimsuggest port", portLine = portLine

--- a/tests/tsuggestapi.nim
+++ b/tests/tsuggestapi.nim
@@ -1,5 +1,6 @@
 import
-  ../suggestapi, os, std/asyncnet, strutils, chronos, chronos/asyncproc, options
+  ../[suggestapi, utils], os, std/asyncnet, strutils, chronos, chronos/asyncproc,
+  options
 import unittest2
 
 const inputLine = "def	skProc	hw.a	proc (){.noSideEffect, gcsafe.}	hw/hw.nim	1	5	\"\"	100"
@@ -93,3 +94,32 @@ suite "Nimsuggest error handling":
     waitFor sleepAsync(300)
 
     check errorCount == 1
+
+suite "Nimsuggest shutdown":
+  let helloWorldFile = getCurrentDir() / "tests/projects/hw/hw.nim"
+
+  test "the spawned process is published before startup finishes":
+    var published: AsyncProcessRef
+    let projectFut = createNimsuggest(
+      helloWorldFile,
+      "nimsuggest",
+      "",
+      REQUEST_TIMEOUT,
+      proc(ns: Nimsuggest) {.gcsafe, raises: [].} =
+        discard,
+      proc(pr: Project) {.gcsafe, raises: [].} =
+        discard,
+      getCurrentDir(),
+      false,
+      false,
+      proc(process: AsyncProcessRef) {.gcsafe, raises: [].} =
+        published = process,
+    )
+
+    while published.isNil and not projectFut.finished:
+      waitFor sleepAsync(10.milliseconds)
+    check not published.isNil
+
+    let project = waitFor projectFut.wait(60.seconds)
+    check published == project.process
+    waitFor shutdownChildProcess(project.process)


### PR DESCRIPTION
Changes:

- Keep track of starting nimsuggests to shut them down
- Prevent spawning new nimsuggest instances if shutting down
- Await for the nimsuggest instances to actually shutdown on exit
- Running the tests no longer leave dangling nimsuggests instances

Likely merge #446 first, rebase this, and get rid of the nested waitFor this change adds.