### PR TITLE
CI failures fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
         shell: bash
         run: nimble test
 
+      - name: Package dir state on failure
+        #if: failure()
+        shell: bash
+        run: ls -la ~/.nimble/pkgs2 ~/.nimble/nimbinaries nimbledeps/pkgs2 || true
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,19 @@ jobs:
         shell: bash
         run: nimble -yld install
 
+      - name: Bootstrap nim track toolchain
+        shell: bash
+        working-directory: tests/projects/trackproject
+        run: nimble setup -ly
+
       - name: Nimble Test
         shell: bash
         run: nimble test
+
+      - name: Package dir state on failure
+        if: failure()
+        shell: bash
+        run: ls -la ~/.nimble/pkgs2 ~/.nimble/nimbinaries nimbledeps/pkgs2 || true
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: "0 19 * * *"
 
+concurrency: # Cancel stale PR builds (but not push builds)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,6 @@ jobs:
         shell: bash
         run: nimble test
 
-      - name: Package dir state on failure
-        if: failure()
-        shell: bash
-        run: ls -la ~/.nimble/pkgs2 ~/.nimble/nimbinaries nimbledeps/pkgs2 || true
-
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-15-intel
+          #- macos-15-intel
           # https://github.com/nim-lang/setup-nimble-action/issues/13
           # - macos-latest
-          - windows-latest
-        attempt: [1, 2, 3, 4, 5]
+          #- windows-latest
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     name: CI / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           # https://github.com/nim-lang/setup-nimble-action/issues/13
           # - macos-latest
           - windows-latest
+        attempt: [1, 2, 3, 4, 5]
     name: CI / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     strategy:
-      fail-fast: false
+      # fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: nimble -yld install
+        run: nimble -yl install -d
 
       - name: Bootstrap nim track toolchain
         shell: bash
         working-directory: tests/projects/trackproject
-        run: nimble setup -ly
+        run: nimble -yl setup
 
       - name: Nimble Test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: nimble test
 
       - name: Package dir state on failure
-        #if: failure()
+        if: failure()
         shell: bash
         run: ls -la ~/.nimble/pkgs2 ~/.nimble/nimbinaries nimbledeps/pkgs2 || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency: # Cancel stale PR builds (but not push builds)
 jobs:
   test:
     strategy:
-      # fail-fast: false
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/ls.nim
+++ b/ls.nim
@@ -171,6 +171,7 @@ type
     storageDir*: string
     cmdLineClientProcessId*: Option[int]
     nimDumpCache*: Table[string, NimbleDumpInfo] #path to NimbleDumpInfo
+    nimDumpInFlight*: Table[string, Future[NimbleDumpInfo]]
     entryPoints*: seq[string]
     responseMap*: TableRef[string, Future[JsonNode]]
     testRunProcess*: Option[AsyncProcessRef]
@@ -271,18 +272,12 @@ proc supportSignatureHelp*(cc: LspClientCapabilities): bool =
   let caps = cc.textDocument
   caps.isSome and caps.get.signatureHelp.isSome
 
-proc getNimbleDumpInfo*(
+proc getNimbleDumpInfoImpl(
     ls: LanguageServer, nimbleFile: string, workingDir = ""
 ): Future[NimbleDumpInfo] {.async.} =
-  if nimbleFile in ls.nimDumpCache:
-    return ls.nimDumpCache.getOrDefault(nimbleFile)
-  var process: AsyncProcessRef
-  let dumpCwd = nimbleFile.parentDir()
   debug "nimble dump starting",
-    nimbleFile = nimbleFile,
-    cwd = dumpCwd,
-    workingDir = workingDir,
-    nimbleDir = getEnv("NIMBLE_DIR")
+    nimbleFile = nimbleFile, nimbleDir = getEnv("NIMBLE_DIR")
+  var process: AsyncProcessRef
   try:
     process = await startProcess(
       "nimble",
@@ -315,17 +310,31 @@ proc getNimbleDumpInfo*(
       ls.nimDumpCache[nimbleFile] = result
 
     debug "nimble dump finished",
-      nimbleFile = nimbleFile,
-      cwd = dumpCwd,
-      nimDir = result.nimDir.get(""),
-      name = result.name,
-      outputLen = info.len
+      nimbleFile = nimbleFile, nimDir = result.nimDir.get("")
   except OSError, IOError, AsyncProcessError:
     debug "Failed to get nimble dump info",
-      nimbleFile = nimbleFile, cwd = dumpCwd, err = getCurrentExceptionMsg()
+      nimbleFile = nimbleFile, err = getCurrentExceptionMsg()
   finally:
     if process != nil:
       await shutdownChildProcess(process)
+
+proc getNimbleDumpInfo*(
+    ls: LanguageServer, nimbleFile: string, workingDir = ""
+): Future[NimbleDumpInfo] {.async.} =
+  if nimbleFile in ls.nimDumpCache:
+    return ls.nimDumpCache.getOrDefault(nimbleFile)
+
+  let inFlight = ls.nimDumpInFlight.getOrDefault(nimbleFile)
+  if not inFlight.isNil and not inFlight.finished:
+    return await inFlight
+
+  let dump = ls.getNimbleDumpInfoImpl(nimbleFile, workingDir)
+  ls.nimDumpInFlight[nimbleFile] = dump
+  try:
+    result = await dump
+  finally:
+    if ls.nimDumpInFlight.getOrDefault(nimbleFile) == dump:
+      ls.nimDumpInFlight.del(nimbleFile)
 
 proc parseWorkspaceConfiguration*(conf: JsonNode): NlsConfig =
   try:

--- a/ls.nim
+++ b/ls.nim
@@ -171,7 +171,6 @@ type
     storageDir*: string
     cmdLineClientProcessId*: Option[int]
     nimDumpCache*: Table[string, NimbleDumpInfo] #path to NimbleDumpInfo
-    nimDumpInFlight*: Table[string, Future[NimbleDumpInfo]]
     entryPoints*: seq[string]
     responseMap*: TableRef[string, Future[JsonNode]]
     testRunProcess*: Option[AsyncProcessRef]
@@ -272,16 +271,12 @@ proc supportSignatureHelp*(cc: LspClientCapabilities): bool =
   let caps = cc.textDocument
   caps.isSome and caps.get.signatureHelp.isSome
 
-proc getNimbleDumpInfoImpl(
+proc getNimbleDumpInfo*(
     ls: LanguageServer, nimbleFile: string, workingDir = ""
 ): Future[NimbleDumpInfo] {.async.} =
+  if nimbleFile in ls.nimDumpCache:
+    return ls.nimDumpCache.getOrDefault(nimbleFile)
   var process: AsyncProcessRef
-  let dumpCwd = nimbleFile.parentDir()
-  debug "nimble dump starting",
-    nimbleFile = nimbleFile,
-    cwd = dumpCwd,
-    workingDir = workingDir,
-    nimbleDir = getEnv("NIMBLE_DIR")
   try:
     process = await startProcess(
       "nimble",
@@ -312,37 +307,11 @@ proc getNimbleDumpInfoImpl(
       nimbleFile = result.nimblePath.get
     if nimbleFile != "":
       ls.nimDumpCache[nimbleFile] = result
-
-    debug "nimble dump finished",
-      nimbleFile = nimbleFile,
-      cwd = dumpCwd,
-      nimDir = result.nimDir.get(""),
-      name = result.name,
-      outputLen = info.len
   except OSError, IOError, AsyncProcessError:
-    debug "Failed to get nimble dump info",
-      nimbleFile = nimbleFile, cwd = dumpCwd, err = getCurrentExceptionMsg()
+    debug "Failed to get nimble dump info", nimbleFile = nimbleFile
   finally:
     if process != nil:
       await shutdownChildProcess(process)
-
-proc getNimbleDumpInfo*(
-    ls: LanguageServer, nimbleFile: string, workingDir = ""
-): Future[NimbleDumpInfo] {.async.} =
-  if nimbleFile in ls.nimDumpCache:
-    return ls.nimDumpCache.getOrDefault(nimbleFile)
-
-  let inFlight = ls.nimDumpInFlight.getOrDefault(nimbleFile)
-  if not inFlight.isNil and not inFlight.finished:
-    return await inFlight
-
-  let dump = ls.getNimbleDumpInfoImpl(nimbleFile, workingDir)
-  ls.nimDumpInFlight[nimbleFile] = dump
-  try:
-    await dump
-  finally:
-    if ls.nimDumpInFlight.getOrDefault(nimbleFile) == dump:
-      ls.nimDumpInFlight.del(nimbleFile)
 
 proc parseWorkspaceConfiguration*(conf: JsonNode): NlsConfig =
   try:

--- a/ls.nim
+++ b/ls.nim
@@ -171,6 +171,7 @@ type
     storageDir*: string
     cmdLineClientProcessId*: Option[int]
     nimDumpCache*: Table[string, NimbleDumpInfo] #path to NimbleDumpInfo
+    nimDumpInFlight*: Table[string, Future[NimbleDumpInfo]]
     entryPoints*: seq[string]
     responseMap*: TableRef[string, Future[JsonNode]]
     testRunProcess*: Option[AsyncProcessRef]
@@ -271,11 +272,9 @@ proc supportSignatureHelp*(cc: LspClientCapabilities): bool =
   let caps = cc.textDocument
   caps.isSome and caps.get.signatureHelp.isSome
 
-proc getNimbleDumpInfo*(
+proc getNimbleDumpInfoImpl(
     ls: LanguageServer, nimbleFile: string, workingDir = ""
 ): Future[NimbleDumpInfo] {.async.} =
-  if nimbleFile in ls.nimDumpCache:
-    return ls.nimDumpCache.getOrDefault(nimbleFile)
   var process: AsyncProcessRef
   let dumpCwd = nimbleFile.parentDir()
   debug "nimble dump starting",
@@ -326,6 +325,24 @@ proc getNimbleDumpInfo*(
   finally:
     if process != nil:
       await shutdownChildProcess(process)
+
+proc getNimbleDumpInfo*(
+    ls: LanguageServer, nimbleFile: string, workingDir = ""
+): Future[NimbleDumpInfo] {.async.} =
+  if nimbleFile in ls.nimDumpCache:
+    return ls.nimDumpCache.getOrDefault(nimbleFile)
+
+  let inFlight = ls.nimDumpInFlight.getOrDefault(nimbleFile)
+  if not inFlight.isNil and not inFlight.finished:
+    return await inFlight
+
+  let dump = ls.getNimbleDumpInfoImpl(nimbleFile, workingDir)
+  ls.nimDumpInFlight[nimbleFile] = dump
+  try:
+    await dump
+  finally:
+    if ls.nimDumpInFlight.getOrDefault(nimbleFile) == dump:
+      ls.nimDumpInFlight.del(nimbleFile)
 
 proc parseWorkspaceConfiguration*(conf: JsonNode): NlsConfig =
   try:

--- a/ls.nim
+++ b/ls.nim
@@ -277,6 +277,12 @@ proc getNimbleDumpInfo*(
   if nimbleFile in ls.nimDumpCache:
     return ls.nimDumpCache.getOrDefault(nimbleFile)
   var process: AsyncProcessRef
+  let dumpCwd = nimbleFile.parentDir()
+  debug "nimble dump starting",
+    nimbleFile = nimbleFile,
+    cwd = dumpCwd,
+    workingDir = workingDir,
+    nimbleDir = getEnv("NIMBLE_DIR")
   try:
     process = await startProcess(
       "nimble",
@@ -307,8 +313,16 @@ proc getNimbleDumpInfo*(
       nimbleFile = result.nimblePath.get
     if nimbleFile != "":
       ls.nimDumpCache[nimbleFile] = result
+
+    debug "nimble dump finished",
+      nimbleFile = nimbleFile,
+      cwd = dumpCwd,
+      nimDir = result.nimDir.get(""),
+      name = result.name,
+      outputLen = info.len
   except OSError, IOError, AsyncProcessError:
-    debug "Failed to get nimble dump info", nimbleFile = nimbleFile
+    debug "Failed to get nimble dump info",
+      nimbleFile = nimbleFile, cwd = dumpCwd, err = getCurrentExceptionMsg()
   finally:
     if process != nil:
       await shutdownChildProcess(process)

--- a/nimlangserver.nimble
+++ b/nimlangserver.nimble
@@ -17,6 +17,7 @@ requires "nim >= 2.2.10",
   "."
 
 task test, "run tests":
+  delEnv("NIMBLE_DIR")
   --run
   --silent
   setCommand("c", "tests/all.nim")

--- a/nimlangserver.nimble
+++ b/nimlangserver.nimble
@@ -17,7 +17,6 @@ requires "nim >= 2.2.10",
   "."
 
 task test, "run tests":
-  delEnv("NIMBLE_DIR")
   --run
   --silent
   setCommand("c", "tests/all.nim")

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -1,9 +1,18 @@
 import
   tsuggestapi,
-  tnimlangserver,
-  tnimtrack,
+  tnimlangserver
+
+# XXX Fix getNimPath not finding nim on windows
+when not defined(windows):
+  import
+    tnimtrack
+
+import
   tprojectsetup,
   tmisc,
   ttestrunner,
-  tmcp,
+  tmcp
+
+# XXX task* messes the env vars
+import
   textensions

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -13,6 +13,6 @@ import
   ttestrunner,
   tmcp
 
-# XXX task* messes the env vars
+# https://github.com/nim-lang/langserver/pull/451
 import
   textensions

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -1,18 +1,9 @@
 import
   tsuggestapi,
-  tnimlangserver
-
-# XXX Fix getNimPath not finding nim on windows
-when not defined(windows):
-  import
-    tnimtrack
-
-import
+  tnimlangserver,
+  tnimtrack,
   tprojectsetup,
+  textensions,
   tmisc,
   ttestrunner,
   tmcp
-
-# https://github.com/nim-lang/langserver/pull/451
-import
-  textensions

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -3,7 +3,7 @@ import
   tnimlangserver,
   tnimtrack,
   tprojectsetup,
-  textensions,
   tmisc,
   ttestrunner,
-  tmcp
+  tmcp,
+  textensions

--- a/tests/all.nim.cfg
+++ b/tests/all.nim.cfg
@@ -5,4 +5,4 @@
 --define:"chronicles_thread_ids=no"
 --define:"debugLogging"
 --define:"chronicles_log_level=DEBUG"
---define:"chronicles_timestamps=None"
+--define:"chronicles_timestamps=UnixTime"

--- a/tests/tnimtrack.nim
+++ b/tests/tnimtrack.nim
@@ -60,7 +60,7 @@ suite "Nim track with nim >= 2.4":
         waitFor client.call("textDocument/definition", %positionParams), seq[Location]
       )
     check locations.len == 1
-    check locations[0].uri.pathToUri().contains("trackproject.nim")
+    check locations.len == 1 and locations[0].uri.pathToUri().contains("trackproject.nim")
 
   test "References with nim track":
     client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))

--- a/tests/tnimtrack.nim
+++ b/tests/tnimtrack.nim
@@ -10,8 +10,12 @@ suite "Nim track with nim >= 2.4":
   let trackProjectDir = absolutePath("tests" / "projects" / "trackproject")
   let savedDir = getCurrentDir()
   setCurrentDir(trackProjectDir)
-  discard execCmdEx("nimble setup -ly")
+  let (setupOutput, setupExitCode) = execCmdEx("nimble setup -ly")
   setCurrentDir(savedDir)
+
+  test "nimble setup for the track project succeeds":
+    checkpoint setupOutput
+    check setupExitCode == 0
 
   let cmdParams =
     CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())

--- a/tests/tnimtrack.nim
+++ b/tests/tnimtrack.nim
@@ -1,134 +1,132 @@
-# XXX Fix getNimPath not finding nim on windows
-when not defined(windows):
-  import ../[nimlangserver, ls, lstransports, utils]
-  import ../protocol/[enums, types]
-  import std/[options, json, os, osproc, jsonutils, sequtils, strutils, strformat]
-  import json_rpc/[rpcclient]
-  import chronicles
-  import lspsocketclient
-  import unittest2
+import ../[nimlangserver, ls, lstransports, utils]
+import ../protocol/[enums, types]
+import std/[options, json, os, osproc, jsonutils, sequtils, strutils, strformat]
+import json_rpc/[rpcclient]
+import chronicles
+import lspsocketclient
+import unittest2
 
-  suite "Nim track with nim >= 2.4":
-    let trackProjectDir = absolutePath("tests" / "projects" / "trackproject")
-    let savedDir = getCurrentDir()
-    setCurrentDir(trackProjectDir)
-    let (setupOutput, setupExitCode) = execCmdEx("nimble -yl setup")
-    setCurrentDir(savedDir)
+suite "Nim track with nim >= 2.4":
+  let trackProjectDir = absolutePath("tests" / "projects" / "trackproject")
+  let savedDir = getCurrentDir()
+  setCurrentDir(trackProjectDir)
+  let (setupOutput, setupExitCode) = execCmdEx("nimble -yl setup")
+  setCurrentDir(savedDir)
 
-    test "nimble setup for the track project succeeds":
-      checkpoint setupOutput
-      check setupExitCode == 0
+  test "nimble setup for the track project succeeds":
+    checkpoint setupOutput
+    check setupExitCode == 0
 
-    let cmdParams =
-      CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
-    let ls = main(cmdParams)
-    let client = newLspSocketClient()
-    client.registerNotification(
-      "window/showMessage", "extension/statusUpdate", "textDocument/publishDiagnostics",
-      "$/progress",
-    )
-    waitFor client.connect("localhost", cmdParams.port)
+  let cmdParams =
+    CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
+  let ls = main(cmdParams)
+  let client = newLspSocketClient()
+  client.registerNotification(
+    "window/showMessage", "extension/statusUpdate", "textDocument/publishDiagnostics",
+    "$/progress",
+  )
+  waitFor client.connect("localhost", cmdParams.port)
 
-    let conf = NlsConfig(useNimTrack: some true)
-    ls.workspaceConfiguration = newFuture[JsonNode]()
-    ls.workspaceConfiguration.complete(% @[conf])
+  let conf = NlsConfig(useNimTrack: some true)
+  ls.workspaceConfiguration = newFuture[JsonNode]()
+  ls.workspaceConfiguration.complete(% @[conf])
 
-    let initParams =
-      LspInitializeParams %* {
-        "processId": %getCurrentProcessId(),
-        "rootUri": fixtureUri("projects/trackproject/"),
-        "capabilities": {"window": {"workDoneProgress": false}},
-      }
-    discard waitFor client.initialize(initParams)
+  let initParams =
+    LspInitializeParams %* {
+      "processId": %getCurrentProcessId(),
+      "rootUri": fixtureUri("projects/trackproject/"),
+      "capabilities": {"window": {"workDoneProgress": false}},
+    }
+  discard waitFor client.initialize(initParams)
 
-    let trackFile = "projects/trackproject/src/trackproject.nim"
+  let trackFile = "projects/trackproject/src/trackproject.nim"
+  client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
+
+  let trackAbsFile = trackFile.fixtureUri.uriToPath
+  check waitFor client.waitForNotificationMessage(
+    fmt"Nimsuggest initialized for {trackAbsFile}"
+  )
+
+  let trackUri = fixtureUri("projects/trackproject/src/trackproject.nim")
+
+  test "Definition with nim track":
     client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
-
-    let trackAbsFile = trackFile.fixtureUri.uriToPath
-    check waitFor client.waitForNotificationMessage(
+    discard waitFor client.waitForNotificationMessage(
       fmt"Nimsuggest initialized for {trackAbsFile}"
     )
-
-    let trackUri = fixtureUri("projects/trackproject/src/trackproject.nim")
-
-    test "Definition with nim track":
-      client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
-      discard waitFor client.waitForNotificationMessage(
-        fmt"Nimsuggest initialized for {trackAbsFile}"
+    let
+      positionParams = positionParams(trackUri, 4, 6)
+      locations = to(
+        waitFor client.call("textDocument/definition", %positionParams), seq[Location]
       )
-      let
-        positionParams = positionParams(trackUri, 4, 6)
-        locations = to(
-          waitFor client.call("textDocument/definition", %positionParams), seq[Location]
-        )
-      check locations.len == 1
-      check locations.len == 1 and locations[0].uri.pathToUri().contains("trackproject.nim")
+    check locations.len == 1
+    check locations.len == 1 and locations[0].uri.pathToUri().contains("trackproject.nim")
 
-    test "References with nim track":
-      client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
-      discard waitFor client.waitForNotificationMessage(
-        fmt"Nimsuggest initialized for {trackAbsFile}"
-      )
-      let referenceParams =
-        ReferenceParams %* {
-          "context": {"includeDeclaration": false},
-          "position": {"line": 4, "character": 6},
-          "textDocument": {"uri": trackUri},
-        }
-      let locations = to(
-        waitFor client.call("textDocument/references", %referenceParams), seq[Location]
-      )
-      check locations.len >= 1
-
-  suite "Nim track unavailable with nim < 2.4":
-    let cmdParams =
-      CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
-    let ls = main(cmdParams)
-    let client = newLspSocketClient()
-    client.registerNotification(
-      "window/showMessage", "extension/statusUpdate", "textDocument/publishDiagnostics",
-      "$/progress",
+  test "References with nim track":
+    client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
+    discard waitFor client.waitForNotificationMessage(
+      fmt"Nimsuggest initialized for {trackAbsFile}"
     )
-    waitFor client.connect("localhost", cmdParams.port)
-
-    let conf = NlsConfig(useNimTrack: some true)
-    ls.workspaceConfiguration = newFuture[JsonNode]()
-    ls.workspaceConfiguration.complete(% @[conf])
-
-    let initParams =
-      LspInitializeParams %* {
-        "processId": %getCurrentProcessId(),
-        "rootUri": fixtureUri("projects/hw/"),
-        "capabilities": {"window": {"workDoneProgress": false}},
+    let referenceParams =
+      ReferenceParams %* {
+        "context": {"includeDeclaration": false},
+        "position": {"line": 4, "character": 6},
+        "textDocument": {"uri": trackUri},
       }
-    discard waitFor client.initialize(initParams)
-
-    let hwFile = "projects/hw/hw.nim"
-    client.notify("textDocument/didOpen", %createDidOpenParams(hwFile))
-
-    let hwAbsFile = hwFile.fixtureUri.uriToPath
-    check waitFor client.waitForNotificationMessage(
-      fmt"Nimsuggest initialized for {hwAbsFile}"
+    let locations = to(
+      waitFor client.call("textDocument/references", %referenceParams), seq[Location]
     )
+    check locations.len >= 1
 
-    let hwUri = fixtureUri("projects/hw/hw.nim")
+suite "Nim track unavailable with nim < 2.4":
+  let cmdParams =
+    CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
+  let ls = main(cmdParams)
+  let client = newLspSocketClient()
+  client.registerNotification(
+    "window/showMessage", "extension/statusUpdate", "textDocument/publishDiagnostics",
+    "$/progress",
+  )
+  waitFor client.connect("localhost", cmdParams.port)
 
-    test "Definition returns empty":
-      let
-        positionParams = positionParams(hwUri, 1, 6)
-        locations = to(
-          waitFor client.call("textDocument/definition", %positionParams), seq[Location]
-        )
-      check locations.len == 0
+  let conf = NlsConfig(useNimTrack: some true)
+  ls.workspaceConfiguration = newFuture[JsonNode]()
+  ls.workspaceConfiguration.complete(% @[conf])
 
-    test "References returns empty":
-      let referenceParams =
-        ReferenceParams %* {
-          "context": {"includeDeclaration": false},
-          "position": {"line": 1, "character": 6},
-          "textDocument": {"uri": hwUri},
-        }
-      let locations = to(
-        waitFor client.call("textDocument/references", %referenceParams), seq[Location]
+  let initParams =
+    LspInitializeParams %* {
+      "processId": %getCurrentProcessId(),
+      "rootUri": fixtureUri("projects/hw/"),
+      "capabilities": {"window": {"workDoneProgress": false}},
+    }
+  discard waitFor client.initialize(initParams)
+
+  let hwFile = "projects/hw/hw.nim"
+  client.notify("textDocument/didOpen", %createDidOpenParams(hwFile))
+
+  let hwAbsFile = hwFile.fixtureUri.uriToPath
+  check waitFor client.waitForNotificationMessage(
+    fmt"Nimsuggest initialized for {hwAbsFile}"
+  )
+
+  let hwUri = fixtureUri("projects/hw/hw.nim")
+
+  test "Definition returns empty":
+    let
+      positionParams = positionParams(hwUri, 1, 6)
+      locations = to(
+        waitFor client.call("textDocument/definition", %positionParams), seq[Location]
       )
-      check locations.len == 0
+    check locations.len == 0
+
+  test "References returns empty":
+    let referenceParams =
+      ReferenceParams %* {
+        "context": {"includeDeclaration": false},
+        "position": {"line": 1, "character": 6},
+        "textDocument": {"uri": hwUri},
+      }
+    let locations = to(
+      waitFor client.call("textDocument/references", %referenceParams), seq[Location]
+    )
+    check locations.len == 0

--- a/tests/tnimtrack.nim
+++ b/tests/tnimtrack.nim
@@ -1,132 +1,134 @@
-import ../[nimlangserver, ls, lstransports, utils]
-import ../protocol/[enums, types]
-import std/[options, json, os, osproc, jsonutils, sequtils, strutils, strformat]
-import json_rpc/[rpcclient]
-import chronicles
-import lspsocketclient
-import unittest2
+# XXX Fix getNimPath not finding nim on windows
+when not defined(windows):
+  import ../[nimlangserver, ls, lstransports, utils]
+  import ../protocol/[enums, types]
+  import std/[options, json, os, osproc, jsonutils, sequtils, strutils, strformat]
+  import json_rpc/[rpcclient]
+  import chronicles
+  import lspsocketclient
+  import unittest2
 
-suite "Nim track with nim >= 2.4":
-  let trackProjectDir = absolutePath("tests" / "projects" / "trackproject")
-  let savedDir = getCurrentDir()
-  setCurrentDir(trackProjectDir)
-  let (setupOutput, setupExitCode) = execCmdEx("nimble setup -ly")
-  setCurrentDir(savedDir)
+  suite "Nim track with nim >= 2.4":
+    let trackProjectDir = absolutePath("tests" / "projects" / "trackproject")
+    let savedDir = getCurrentDir()
+    setCurrentDir(trackProjectDir)
+    let (setupOutput, setupExitCode) = execCmdEx("nimble -yl setup")
+    setCurrentDir(savedDir)
 
-  test "nimble setup for the track project succeeds":
-    checkpoint setupOutput
-    check setupExitCode == 0
+    test "nimble setup for the track project succeeds":
+      checkpoint setupOutput
+      check setupExitCode == 0
 
-  let cmdParams =
-    CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
-  let ls = main(cmdParams)
-  let client = newLspSocketClient()
-  client.registerNotification(
-    "window/showMessage", "extension/statusUpdate", "textDocument/publishDiagnostics",
-    "$/progress",
-  )
-  waitFor client.connect("localhost", cmdParams.port)
+    let cmdParams =
+      CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
+    let ls = main(cmdParams)
+    let client = newLspSocketClient()
+    client.registerNotification(
+      "window/showMessage", "extension/statusUpdate", "textDocument/publishDiagnostics",
+      "$/progress",
+    )
+    waitFor client.connect("localhost", cmdParams.port)
 
-  let conf = NlsConfig(useNimTrack: some true)
-  ls.workspaceConfiguration = newFuture[JsonNode]()
-  ls.workspaceConfiguration.complete(% @[conf])
+    let conf = NlsConfig(useNimTrack: some true)
+    ls.workspaceConfiguration = newFuture[JsonNode]()
+    ls.workspaceConfiguration.complete(% @[conf])
 
-  let initParams =
-    LspInitializeParams %* {
-      "processId": %getCurrentProcessId(),
-      "rootUri": fixtureUri("projects/trackproject/"),
-      "capabilities": {"window": {"workDoneProgress": false}},
-    }
-  discard waitFor client.initialize(initParams)
+    let initParams =
+      LspInitializeParams %* {
+        "processId": %getCurrentProcessId(),
+        "rootUri": fixtureUri("projects/trackproject/"),
+        "capabilities": {"window": {"workDoneProgress": false}},
+      }
+    discard waitFor client.initialize(initParams)
 
-  let trackFile = "projects/trackproject/src/trackproject.nim"
-  client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
-
-  let trackAbsFile = trackFile.fixtureUri.uriToPath
-  check waitFor client.waitForNotificationMessage(
-    fmt"Nimsuggest initialized for {trackAbsFile}"
-  )
-
-  let trackUri = fixtureUri("projects/trackproject/src/trackproject.nim")
-
-  test "Definition with nim track":
+    let trackFile = "projects/trackproject/src/trackproject.nim"
     client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
-    discard waitFor client.waitForNotificationMessage(
+
+    let trackAbsFile = trackFile.fixtureUri.uriToPath
+    check waitFor client.waitForNotificationMessage(
       fmt"Nimsuggest initialized for {trackAbsFile}"
     )
-    let
-      positionParams = positionParams(trackUri, 4, 6)
-      locations = to(
-        waitFor client.call("textDocument/definition", %positionParams), seq[Location]
+
+    let trackUri = fixtureUri("projects/trackproject/src/trackproject.nim")
+
+    test "Definition with nim track":
+      client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
+      discard waitFor client.waitForNotificationMessage(
+        fmt"Nimsuggest initialized for {trackAbsFile}"
       )
-    check locations.len == 1
-    check locations.len == 1 and locations[0].uri.pathToUri().contains("trackproject.nim")
+      let
+        positionParams = positionParams(trackUri, 4, 6)
+        locations = to(
+          waitFor client.call("textDocument/definition", %positionParams), seq[Location]
+        )
+      check locations.len == 1
+      check locations.len == 1 and locations[0].uri.pathToUri().contains("trackproject.nim")
 
-  test "References with nim track":
-    client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
-    discard waitFor client.waitForNotificationMessage(
-      fmt"Nimsuggest initialized for {trackAbsFile}"
-    )
-    let referenceParams =
-      ReferenceParams %* {
-        "context": {"includeDeclaration": false},
-        "position": {"line": 4, "character": 6},
-        "textDocument": {"uri": trackUri},
-      }
-    let locations = to(
-      waitFor client.call("textDocument/references", %referenceParams), seq[Location]
-    )
-    check locations.len >= 1
-
-suite "Nim track unavailable with nim < 2.4":
-  let cmdParams =
-    CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
-  let ls = main(cmdParams)
-  let client = newLspSocketClient()
-  client.registerNotification(
-    "window/showMessage", "extension/statusUpdate", "textDocument/publishDiagnostics",
-    "$/progress",
-  )
-  waitFor client.connect("localhost", cmdParams.port)
-
-  let conf = NlsConfig(useNimTrack: some true)
-  ls.workspaceConfiguration = newFuture[JsonNode]()
-  ls.workspaceConfiguration.complete(% @[conf])
-
-  let initParams =
-    LspInitializeParams %* {
-      "processId": %getCurrentProcessId(),
-      "rootUri": fixtureUri("projects/hw/"),
-      "capabilities": {"window": {"workDoneProgress": false}},
-    }
-  discard waitFor client.initialize(initParams)
-
-  let hwFile = "projects/hw/hw.nim"
-  client.notify("textDocument/didOpen", %createDidOpenParams(hwFile))
-
-  let hwAbsFile = hwFile.fixtureUri.uriToPath
-  check waitFor client.waitForNotificationMessage(
-    fmt"Nimsuggest initialized for {hwAbsFile}"
-  )
-
-  let hwUri = fixtureUri("projects/hw/hw.nim")
-
-  test "Definition returns empty":
-    let
-      positionParams = positionParams(hwUri, 1, 6)
-      locations = to(
-        waitFor client.call("textDocument/definition", %positionParams), seq[Location]
+    test "References with nim track":
+      client.notify("textDocument/didOpen", %createDidOpenParams(trackFile))
+      discard waitFor client.waitForNotificationMessage(
+        fmt"Nimsuggest initialized for {trackAbsFile}"
       )
-    check locations.len == 0
+      let referenceParams =
+        ReferenceParams %* {
+          "context": {"includeDeclaration": false},
+          "position": {"line": 4, "character": 6},
+          "textDocument": {"uri": trackUri},
+        }
+      let locations = to(
+        waitFor client.call("textDocument/references", %referenceParams), seq[Location]
+      )
+      check locations.len >= 1
 
-  test "References returns empty":
-    let referenceParams =
-      ReferenceParams %* {
-        "context": {"includeDeclaration": false},
-        "position": {"line": 1, "character": 6},
-        "textDocument": {"uri": hwUri},
-      }
-    let locations = to(
-      waitFor client.call("textDocument/references", %referenceParams), seq[Location]
+  suite "Nim track unavailable with nim < 2.4":
+    let cmdParams =
+      CommandLineParams(mode: some lsp, transport: some socket, port: getNextFreePort())
+    let ls = main(cmdParams)
+    let client = newLspSocketClient()
+    client.registerNotification(
+      "window/showMessage", "extension/statusUpdate", "textDocument/publishDiagnostics",
+      "$/progress",
     )
-    check locations.len == 0
+    waitFor client.connect("localhost", cmdParams.port)
+
+    let conf = NlsConfig(useNimTrack: some true)
+    ls.workspaceConfiguration = newFuture[JsonNode]()
+    ls.workspaceConfiguration.complete(% @[conf])
+
+    let initParams =
+      LspInitializeParams %* {
+        "processId": %getCurrentProcessId(),
+        "rootUri": fixtureUri("projects/hw/"),
+        "capabilities": {"window": {"workDoneProgress": false}},
+      }
+    discard waitFor client.initialize(initParams)
+
+    let hwFile = "projects/hw/hw.nim"
+    client.notify("textDocument/didOpen", %createDidOpenParams(hwFile))
+
+    let hwAbsFile = hwFile.fixtureUri.uriToPath
+    check waitFor client.waitForNotificationMessage(
+      fmt"Nimsuggest initialized for {hwAbsFile}"
+    )
+
+    let hwUri = fixtureUri("projects/hw/hw.nim")
+
+    test "Definition returns empty":
+      let
+        positionParams = positionParams(hwUri, 1, 6)
+        locations = to(
+          waitFor client.call("textDocument/definition", %positionParams), seq[Location]
+        )
+      check locations.len == 0
+
+    test "References returns empty":
+      let referenceParams =
+        ReferenceParams %* {
+          "context": {"includeDeclaration": false},
+          "position": {"line": 1, "character": 6},
+          "textDocument": {"uri": hwUri},
+        }
+      let locations = to(
+        waitFor client.call("textDocument/references", %referenceParams), seq[Location]
+      )
+      check locations.len == 0


### PR DESCRIPTION
Changes:

- Build nim#version-2-4 as a CI step. This avoid running the tests that will fail anyway + it shows it takes 20 min to compile VS 3 min of tests runtime. ie: it needs to be removed at some point.
- disable `nim track` tests on windows; workaround to #447
- fix tmcp.nim to wait for nimsuggest initialization; this avoids the `nimble dump` race (read below)
- add debug instrumentation in `getNimbleDumpInfo`

The CI fails sometimes with:

```
ERR NimSuggest Error (stderr)                  err="lineinfos.nim(331)       raiseRecoverableError\nError: unhandled exception: invalid package name: /home/runner/.nimble/pkgs2/csources_v3 [ERecoverableError]\n"
```

The nimsuggest error *seems* to occur in part due to the `textensions` test calls `tasks` which [removes NIMBLE_DIR envvar](https://github.com/nim-lang/langserver/blob/0f5b25e4ec9dd3df0d4c02cb2c6b1837135ac3db/routes/lsp.nim#L880). When `NIMBLE_DIR` is set, nimsuggest inherits it and never checks `~/.nimble/pkgs2`, it checks `nimbledeps/pkgs2` instead; hence the workaround moving `textensions` to the end. But the root cause is whatever creates csources_v3 in pkgs2.

Most likely the root cause is `nimble dump` running concurrently on langserver and leaving leftovers https://github.com/nim-lang/nimble/issues/1857 because of it.

update: from the debugging session, it does seems to occur when two `nimble dump` run concurrently building nim on global nimble pkgs2:

```
741.908525 starting
742.011679 starting  (+103ms)
742.978451 finished  (+1.07s)
930.525240 finished  (+188.6s)
```

^ it seems to be two `nimble dumps` one in LSP and one in MCP racing. Workarounded in tmcp.nim; in real use I think there is no workaround, because LSP and MCP run in their own process, so just fix https://github.com/nim-lang/nimble/issues/1857